### PR TITLE
Allow wrap long lines

### DIFF
--- a/Libraries/Configuration.cs
+++ b/Libraries/Configuration.cs
@@ -31,6 +31,7 @@ namespace Libraries
             IncludedTypes,
             Initial,
             IntelliSense,
+            MaxLineLength,
             PortExceptionsExisting,
             PortExceptionsNew,
             PortMemberParams,
@@ -69,6 +70,7 @@ namespace Libraries
         public HashSet<string> IncludedAssemblies { get; } = new HashSet<string>();
         public HashSet<string> IncludedNamespaces { get; } = new HashSet<string>();
         public HashSet<string> IncludedTypes { get; } = new HashSet<string>();
+        public int MaxLineLength { get; set; } = 0;
         public bool PortExceptionsExisting { get; set; } = false;
         public bool PortExceptionsNew { get; set; } = true;
         public bool PortMemberParams { get; set; } = true;
@@ -398,6 +400,10 @@ namespace Libraries
                                     mode = Mode.IntelliSense;
                                     break;
 
+                                case "-MAXLINELENGTH":
+                                    mode = Mode.MaxLineLength;
+                                    break;
+
                                 case "-PORTEXCEPTIONSEXISTING":
                                     mode = Mode.PortExceptionsExisting;
                                     break;
@@ -485,6 +491,30 @@ namespace Libraries
                                 config.DirsIntelliSense.Add(dirInfo);
                                 Log.Info($"  -  {dirPath}");
                             }
+
+                            mode = Mode.Initial;
+                            break;
+                        }
+
+                    case Mode.MaxLineLength:
+                        {
+                            if (!int.TryParse(arg, out int value))
+                            {
+                                throw new Exception($"Invalid int value for 'Max line length' argument: {arg}");
+                            }
+                            else if (value < 0 || value > 200)
+                            {
+                                throw new Exception($"Value needs to be between 0 and 200: {value}");
+                            }
+
+                            config.MaxLineLength = value;
+
+                            Log.Cyan($"Max line length:");
+
+                            string extra = string.Empty;
+                            if (value == 0)
+                                extra = " (no line wrap)";
+                            Log.Info($" - {value}{extra}");
 
                             mode = Mode.Initial;
                             break;

--- a/Libraries/Log.cs
+++ b/Libraries/Log.cs
@@ -365,6 +365,9 @@ Options:
                                                     Usage example:
                                                         -IncludedTypes FileStream,DirectoryInfo
 
+    -MaxLineLength          int (0-200)         Default is 0 (no line wrap).
+                                                Indicates whether triple slash comments must be wrapped once lines exceed the specificed length.
+
     -PortExceptionsExisting     bool            Default is false (does not find and append existing exceptions).
                                                 Enable or disable finding, porting and appending summaries from existing exceptions.
                                                 Setting this to true can result in a lot of noise because there is

--- a/Libraries/ToTripleSlashPorter.cs
+++ b/Libraries/ToTripleSlashPorter.cs
@@ -293,7 +293,7 @@ namespace Libraries
             foreach ((string filePath, LocationInformation info) in ResolvedLocations)
             {
                 Log.Info($"Porting docs for '{filePath}'...");
-                TripleSlashSyntaxRewriter rewriter = new(DocsComments, info.Model);
+                TripleSlashSyntaxRewriter rewriter = new(DocsComments, info.Model, Config);
                 SyntaxNode newRoot = rewriter.Visit(info.Tree.GetRoot())
                     ?? throw new NullReferenceException($"Returned null root node for {info.Api.FullName} in {info.Tree.FilePath}");
 


### PR DESCRIPTION
Fixes #44

* Provide a naive algorithm to wrap long lines on ' ', '.' and ';'
* Allow set line wrap in 0-200 range (0 = no line wrap)
* Force `<summary>` and `<return>` tags to always be on new line
* Multi-line other tags depending whether a rendered tag's length is less than the max line length (if it is > 0).

Before the fix - this is not acceptable in https://github.com/dotnet/winforms as we have existing documentations, which we have been maintaining and wrapping at 120-150 mark:
```diff
     /// <summary>
-    ///  Provides <see langword='static'/> methods and properties to manage an application, such as methods to run and quit an application,
-    ///  to process Windows messages, and properties to get information about an application.
-    ///  This class cannot be inherited.
+    ///  Provides <see langword="static" /> methods and properties to manage an application, such as methods to start and stop an application, to process Windows messages, and properties to get information about an application. This class cannot be inherited.
     /// </summary>
```

With the fix:
```diff
     /// <summary>
-    ///  Provides <see langword='static'/> methods and properties to manage an application, such as methods to run and quit an application,
-    ///  to process Windows messages, and properties to get information about an application.
+    ///  Provides <see langword="static" /> methods and properties to manage an application, such as methods to start
+    ///  and stop an application, to process Windows messages, and properties to get information about an application.
     ///  This class cannot be inherited.
     /// </summary>
```