### PR TITLE
PortToDocs: Add methods that either collect files automatically, or allow passing documents manually

### DIFF
--- a/src/PortToDocs/src/app/PortToDocs.cs
+++ b/src/PortToDocs/src/app/PortToDocs.cs
@@ -11,6 +11,7 @@ namespace ApiDocsSync
         {
             Configuration config = Configuration.GetCLIArguments(args);
             ToDocsPorter porter = new(config);
+            porter.CollectFiles();
             porter.Start();
         }
     }

--- a/src/PortToDocs/src/libraries/IntelliSenseXml/IntelliSenseXmlCommentsContainer.cs
+++ b/src/PortToDocs/src/libraries/IntelliSenseXml/IntelliSenseXmlCommentsContainer.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
-using System.Xml;
 using System.Xml.Linq;
 
 /*
@@ -39,10 +38,7 @@ namespace ApiDocsSync.Libraries.IntelliSenseXml
         // The IntelliSense xml files do not separate types from members, like ECMA xml files do - Everything is a member.
         public Dictionary<string, IntelliSenseXmlMember> Members = new();
 
-        public IntelliSenseXmlCommentsContainer(Configuration config)
-        {
-            Config = config;
-        }
+        public IntelliSenseXmlCommentsContainer(Configuration config) => Config = config;
 
         internal IEnumerable<FileInfo> EnumerateFiles()
         {
@@ -82,15 +78,15 @@ namespace ApiDocsSync.Libraries.IntelliSenseXml
             {
                 foreach (XElement xeMember in xeMembers.Elements("member"))
                 {
-                    IntelliSenseXmlMember member = new IntelliSenseXmlMember(xeMember, assembly);
+                    IntelliSenseXmlMember member = new(xeMember, assembly);
 
-                    if (Config.IncludedAssemblies.Any(included => member.Assembly.StartsWith(included)) &&
-                        !Config.ExcludedAssemblies.Any(excluded => member.Assembly.StartsWith(excluded)))
+                    if (Config.IncludedAssemblies.Any(included => member.Assembly.StartsWith(included, StringComparison.InvariantCultureIgnoreCase)) &&
+                        !Config.ExcludedAssemblies.Any(excluded => member.Assembly.StartsWith(excluded, StringComparison.InvariantCultureIgnoreCase)))
                     {
                         // No namespaces provided by the user means they want to port everything from that assembly
                         if (!Config.IncludedNamespaces.Any() ||
-                                (Config.IncludedNamespaces.Any(included => member.Namespace.StartsWith(included)) &&
-                                !Config.ExcludedNamespaces.Any(excluded => member.Namespace.StartsWith(excluded))))
+                                (Config.IncludedNamespaces.Any(included => member.Namespace.StartsWith(included, StringComparison.InvariantCultureIgnoreCase)) &&
+                                !Config.ExcludedNamespaces.Any(excluded => member.Namespace.StartsWith(excluded, StringComparison.InvariantCultureIgnoreCase))))
                         {
                             totalAdded++;
                             Members.TryAdd(member.Name, member); // is it OK this encounters duplicates?
@@ -106,7 +102,7 @@ namespace ApiDocsSync.Libraries.IntelliSenseXml
         }
 
         // Verifies the file is properly formed while attempting to retrieve the assembly name.
-        private bool TryGetAssemblyName(XDocument? xDoc, string fileName, [NotNullWhen(returnValue: true)] out string? assembly)
+        private static bool TryGetAssemblyName(XDocument? xDoc, string fileName, [NotNullWhen(returnValue: true)] out string? assembly)
         {
             assembly = null;
 

--- a/src/PortToDocs/src/libraries/IntelliSenseXml/IntelliSenseXmlCommentsContainer.cs
+++ b/src/PortToDocs/src/libraries/IntelliSenseXml/IntelliSenseXmlCommentsContainer.cs
@@ -36,8 +36,6 @@ namespace ApiDocsSync.Libraries.IntelliSenseXml
     {
         private Configuration Config { get; set; }
 
-        private XDocument? xDoc = null;
-
         // The IntelliSense xml files do not separate types from members, like ECMA xml files do - Everything is a member.
         public Dictionary<string, IntelliSenseXmlMember> Members = new();
 
@@ -46,20 +44,7 @@ namespace ApiDocsSync.Libraries.IntelliSenseXml
             Config = config;
         }
 
-        public void CollectFiles()
-        {
-            Log.Info("Looking for IntelliSense xml files...");
-
-            foreach (FileInfo fileInfo in EnumerateFiles())
-            {
-                LoadFile(fileInfo, printSuccess: true);
-            }
-
-            Log.Success("Finished looking for IntelliSense xml files.");
-            Log.Line();
-        }
-
-        private IEnumerable<FileInfo> EnumerateFiles()
+        internal IEnumerable<FileInfo> EnumerateFiles()
         {
             foreach (DirectoryInfo dirInfo in Config.DirsIntelliSense)
             {
@@ -85,19 +70,9 @@ namespace ApiDocsSync.Libraries.IntelliSenseXml
             }
         }
 
-        private void LoadFile(FileInfo fileInfo, bool printSuccess)
+        internal void LoadIntellisenseXmlFile(XDocument xDoc, string filePath)
         {
-            try
-            {
-                xDoc = XDocument.Load(fileInfo.FullName);
-            }
-            catch (Exception ex)
-            {
-                Log.Error($"Failed to load '{fileInfo.FullName}'. {ex}");
-                return;
-            }
-
-            if (!TryGetAssemblyName(xDoc, fileInfo.FullName, out string? assembly))
+            if (!TryGetAssemblyName(xDoc, filePath, out string? assembly))
             {
                 return;
             }
@@ -124,9 +99,9 @@ namespace ApiDocsSync.Libraries.IntelliSenseXml
                 }
             }
 
-            if (printSuccess && totalAdded > 0)
+            if (totalAdded > 0)
             {
-                Log.Success($"{totalAdded} IntelliSense xml member(s) added from xml file '{fileInfo.FullName}'");
+                Log.Success($"{totalAdded} IntelliSense xml member(s) added from xml file '{filePath}'");
             }
         }
 

--- a/src/PortToDocs/tests/PortToDocs/PortToDocsTests.cs
+++ b/src/PortToDocs/tests/PortToDocs/PortToDocsTests.cs
@@ -190,6 +190,7 @@ namespace ApiDocsSync.Libraries.Tests
             c.DirsIntelliSense.Add(new(Path.Join(targetDir, IntellisenseDir)));
 
             var porter = new ToDocsPorter(c);
+            porter.CollectFiles();
             porter.Start();
 
             Verify(targetDir);

--- a/src/PortToDocs/tests/PortToDocs/PortToDocsTests.cs
+++ b/src/PortToDocs/tests/PortToDocs/PortToDocsTests.cs
@@ -19,27 +19,27 @@ namespace ApiDocsSync.Libraries.Tests
         // Verifies the basic case of porting all regular fields.
         public void Port_Basic()
         {
-            PortToDocs("Basic", GetConfiguration());
+            PortToDocsWithFileSystem("Basic", GetConfiguration());
         }
 
         [Fact]
         public void Port_DontAddMissingRemarks()
         {
-            PortToDocs("DontAddMissingRemarks", GetConfiguration());
+            PortToDocsWithFileSystem("DontAddMissingRemarks", GetConfiguration());
         }
 
         [Fact]
         // Verifies porting of APIs living in namespaces whose name match their assembly.
         public void Port_AssemblyAndNamespaceSame()
         {
-            PortToDocs("AssemblyAndNamespaceSame", GetConfiguration());
+            PortToDocsWithFileSystem("AssemblyAndNamespaceSame", GetConfiguration());
         }
 
         [Fact]
         // Verifies porting of APIs living in namespaces whose name does not match their assembly.
         public void Port_AssemblyAndNamespaceDifferent()
         {
-            PortToDocs("AssemblyAndNamespaceDifferent",
+            PortToDocsWithFileSystem("AssemblyAndNamespaceDifferent",
                        GetConfiguration(),
                        namespaceNames: new[] { TestData.TestNamespace });
         }
@@ -51,7 +51,7 @@ namespace ApiDocsSync.Libraries.Tests
         public void Port_Remarks_NoEII_NoInterfaceRemarks()
         {
             Configuration c = GetConfiguration(skipInterfaceImplementations: true, skipInterfaceRemarks: true);
-            PortToDocs("Remarks_NoEII_NoInterfaceRemarks", c);
+            PortToDocsWithFileSystem("Remarks_NoEII_NoInterfaceRemarks", c);
         }
 
         [Fact]
@@ -61,7 +61,7 @@ namespace ApiDocsSync.Libraries.Tests
         public void Port_Remarks_WithEII_WithInterfaceRemarks()
         {
             Configuration c = GetConfiguration(skipInterfaceImplementations: false, skipInterfaceRemarks: false);
-            PortToDocs("Remarks_WithEII_WithInterfaceRemarks", c);
+            PortToDocsWithFileSystem("Remarks_WithEII_WithInterfaceRemarks", c);
         }
 
         [Fact]
@@ -71,14 +71,14 @@ namespace ApiDocsSync.Libraries.Tests
         public void Port_Remarks_WithEII_NoInterfaceRemarks()
         {
             Configuration c = GetConfiguration(skipInterfaceImplementations: false, skipInterfaceRemarks: true);
-            PortToDocs("Remarks_WithEII_NoInterfaceRemarks", c);
+            PortToDocsWithFileSystem("Remarks_WithEII_NoInterfaceRemarks", c);
         }
 
         [Fact]
         // Verifies that new exceptions are ported.
         public void Port_Exceptions()
         {
-            PortToDocs("Exceptions", GetConfiguration());
+            PortToDocsWithFileSystem("Exceptions", GetConfiguration());
         }
 
         [Fact]
@@ -87,14 +87,14 @@ namespace ApiDocsSync.Libraries.Tests
         public void Port_Exception_ExistingCref()
         {
             Configuration c = GetConfiguration(portExceptionsExisting: true, exceptionCollisionThreshold: 60);
-            PortToDocs("Exception_ExistingCref", c);
+            PortToDocsWithFileSystem("Exception_ExistingCref", c);
         }
 
         [Fact]
         // Avoid porting enum field remarks
         public void Port_EnumRemarks()
         {
-            PortToDocs("EnumRemarks", GetConfiguration());
+            PortToDocsWithFileSystem("EnumRemarks", GetConfiguration());
         }
 
         [Fact]
@@ -102,7 +102,7 @@ namespace ApiDocsSync.Libraries.Tests
         // The parent type is located in a different assembly.
         public void Port_InheritDoc()
         {
-            PortToDocs("InheritDoc",
+            PortToDocsWithFileSystem("InheritDoc",
                        GetConfiguration(),
                        assemblyNames: new[] { TestData.TestAssembly, "System" });
         }
@@ -158,7 +158,7 @@ namespace ApiDocsSync.Libraries.Tests
                 SkipInterfaceRemarks = skipInterfaceRemarks
             };
 
-        private static void PortToDocs(
+        private static void PortToDocsWithFileSystem(
                 string testName,
                 Configuration c,
                 string[] assemblyNames = null,


### PR DESCRIPTION
Unit testing is too hard in the PortToDocs project because the only method we currently use requires creating real files and modifying them as they would in a real use case scenario.

We can keep the tests we already have but we should also have the ability to create tests that don't depend on the filesystem and which allow passing the document to read and the document to write.

This is the first iteration. In the next iteration (maybe next commit, or maybe next PR) I will add unit tests using this simplified process.