### PR TITLE
Detect renamed typeparam, prompt user to select the correct renamed typeparam

### DIFF
--- a/src/PortToDocs/src/app/PortToDocs.cs
+++ b/src/PortToDocs/src/app/PortToDocs.cs
@@ -13,6 +13,8 @@ namespace ApiDocsSync
             ToDocsPorter porter = new(config);
             porter.CollectFiles();
             porter.Start();
+            porter.SaveToDisk();
+            porter.PrintSummary();
         }
     }
 }

--- a/src/PortToDocs/src/libraries/Configuration.cs
+++ b/src/PortToDocs/src/libraries/Configuration.cs
@@ -586,22 +586,28 @@ namespace ApiDocsSync.Libraries
                 Log.ErrorAndExit("You missed an argument value.");
             }
 
-            if (config.DirsDocsXml == null)
-            {
-                Log.ErrorAndExit($"You must specify a path to the dotnet-api-docs xml folder using '-{nameof(Mode.Docs)}'.");
-            }
-
-            if (config.DirsIntelliSense.Count == 0)
-            {
-                Log.ErrorAndExit($"You must specify at least one IntelliSense & DLL folder using '-{nameof(Mode.IntelliSense)}'.");
-            }
-
             if (config.IncludedAssemblies.Count == 0)
             {
                 Log.ErrorAndExit($"You must specify at least one assembly with {nameof(IncludedAssemblies)}.");
             }
 
             return config;
+        }
+
+        internal void VerifyIntellisenseXmlFiles()
+        {
+            if (DirsIntelliSense.Count == 0)
+            {
+                Log.ErrorAndExit($"You must specify at least one IntelliSense & DLL folder using '-{nameof(Mode.IntelliSense)}'.");
+            }
+        }
+
+        internal void VerifyDocsFiles()
+        {
+            if (DirsDocsXml.Count == 0)
+            {
+                Log.ErrorAndExit($"You must specify a path to the dotnet-api-docs xml folder using '-{nameof(Mode.Docs)}'.");
+            }
         }
 
         // Tries to parse the user argument string as boolean, and if it fails, exits the program.

--- a/src/PortToDocs/src/libraries/Configuration.cs
+++ b/src/PortToDocs/src/libraries/Configuration.cs
@@ -68,7 +68,6 @@ namespace ApiDocsSync.Libraries
 
         public readonly string BinLogPath = "output.binlog";
         public bool BinLogger { get; private set; } = false;
-        public FileInfo? CsProj { get; set; }
         public List<DirectoryInfo> DirsIntelliSense { get; } = new List<DirectoryInfo>();
         public List<DirectoryInfo> DirsDocsXml { get; } = new List<DirectoryInfo>();
         public bool DisablePrompts { get; set; } = true;

--- a/src/PortToDocs/src/libraries/Docs/DocsCommentsContainer.cs
+++ b/src/PortToDocs/src/libraries/Docs/DocsCommentsContainer.cs
@@ -20,7 +20,7 @@ namespace ApiDocsSync.Libraries.Docs
 
         public DocsCommentsContainer(Configuration config) => Config = config;
 
-        public void Save()
+        public void SaveToDisk()
         {
             if (!Config.Save)
             {

--- a/src/PortToDocs/src/libraries/ToDocsPorter.cs
+++ b/src/PortToDocs/src/libraries/ToDocsPorter.cs
@@ -37,6 +37,8 @@ namespace ApiDocsSync.Libraries
         public void CollectFiles()
         {
             Log.Info("Looking for IntelliSense xml files...");
+            Config.VerifyIntellisenseXmlFiles();
+
             foreach (FileInfo fileInfo in IntelliSenseXmlComments.EnumerateFiles())
             {
                 XDocument? xDoc = null;
@@ -58,6 +60,8 @@ namespace ApiDocsSync.Libraries
             Log.Line();
 
             Log.Info("Looking for Docs xml files...");
+            Config.VerifyDocsFiles();
+
             foreach (FileInfo fileInfo in DocsComments.EnumerateFiles())
             {
                 XDocument? xDoc = null;

--- a/src/PortToDocs/src/libraries/ToDocsPorter.cs
+++ b/src/PortToDocs/src/libraries/ToDocsPorter.cs
@@ -434,7 +434,7 @@ namespace ApiDocsSync.Libraries
         // Ports all the parameter descriptions for the specified API if any of them is undocumented.
         private void TryPortMissingParamsForAPI(IDocsAPI dApiToUpdate, IntelliSenseXmlMember? tsMemberToPort, DocsMember? interfacedMember)
         {
-            if (dApiToUpdate.Kind == APIKind.Type && !Config.PortTypeParams ||
+            if (dApiToUpdate.Kind == APIKind.Type && !Config.PortTypeParams /* Params of a Type */ ||
                 dApiToUpdate.Kind == APIKind.Member && !Config.PortMemberParams)
             {
                 return;
@@ -559,34 +559,86 @@ namespace ApiDocsSync.Libraries
         // Ports all the type parameter descriptions for the specified API if any of them is undocumented.
         private void TryPortMissingTypeParamsForAPI(IDocsAPI dApiToUpdate, IntelliSenseXmlMember? tsMemberToPort, DocsMember? interfacedMember)
         {
-            if (dApiToUpdate.Kind == APIKind.Type && !Config.PortTypeTypeParams ||
+
+            if (dApiToUpdate.Kind == APIKind.Type && !Config.PortTypeTypeParams /* TypeParams of a Type */ ||
                 dApiToUpdate.Kind == APIKind.Member && !Config.PortMemberTypeParams)
             {
                 return;
             }
 
+            bool created;
+            bool isEII = false;
+            string name;
+            string value;
+
             if (tsMemberToPort != null)
             {
-                foreach (IntelliSenseXmlTypeParam tsTypeParam in tsMemberToPort.TypeParams)
+                foreach (DocsTypeParam dTypeParam in dApiToUpdate.TypeParams)
                 {
-                    bool isEII = false;
-                    string name = string.Empty;
-                    string value = string.Empty;
-
-                    DocsTypeParam? dTypeParam = dApiToUpdate.TypeParams.FirstOrDefault(x => x.Name == tsTypeParam.Name);
-
-                    if (dTypeParam == null)
-                    {
-                        ProblematicAPIs.AddIfNotExists($"Can't find intellisense typeparam in docs: TypeParam=[{tsTypeParam.Name}] in Member=[{dApiToUpdate.DocId}]");
-                        dTypeParam = dApiToUpdate.AddTypeParam(tsTypeParam.Name, XmlHelper.GetNodesInPlainText(tsTypeParam.XETypeParam));
-                    }
-
-                    // But it can still be empty, try to retrieve it
                     if (dTypeParam.Value.IsDocsEmpty())
                     {
-                        // try to port IntelliSense xml comments
-                        if (!tsTypeParam.Value.IsDocsEmpty())
+                        created = false;
+                        isEII = false;
+                        name = string.Empty;
+                        value = string.Empty;
+
+                        IntelliSenseXmlTypeParam? tsTypeParam = tsMemberToPort.TypeParams.FirstOrDefault(x => x.Name == dTypeParam.Name);
+
+                        // When not found, it's a bug in Docs (typeparam name not the same as source/ref), so need to ask the user to indicate correct name
+                        if (tsTypeParam == null)
                         {
+                            string msg;
+                            if (tsMemberToPort.TypeParams.Count() == 0)
+                            {
+                                msg = $"There were no IntelliSense xml comments for typeparam {dTypeParam.Name} in Member DocId {dApiToUpdate.DocId}";
+                                ProblematicAPIs.AddIfNotExists(msg);
+                                Log.Warning(msg);
+                            }
+                            else if (tsMemberToPort.TypeParams.Count() != dApiToUpdate.TypeParams.Count())
+                            {
+                                msg = $"The total number of typeparams does not match between IntelliSense and Docs members {dApiToUpdate.DocId}";
+                                ProblematicAPIs.AddIfNotExists(msg);
+                                Log.Warning(msg);
+                            }
+                            else
+                            {
+                                created = TryPromptTypeParam(dTypeParam, tsMemberToPort, out IntelliSenseXmlTypeParam? newTsTypeParam);
+                                if (newTsTypeParam == null)
+                                {
+                                    msg = $"The typeparam {dTypeParam.Name} was not found in IntelliSense xml for {dApiToUpdate.DocId}";
+                                    ProblematicAPIs.AddIfNotExists(msg);
+                                    Log.Error(msg);
+                                }
+                                else
+                                {
+                                    // Now attempt to document it
+                                    if (!newTsTypeParam.Value.IsDocsEmpty())
+                                    {
+                                        // try to port IntelliSense xml comments
+                                        dTypeParam.Value = newTsTypeParam.Value;
+                                        name = newTsTypeParam.Name;
+                                        value = newTsTypeParam.Value;
+                                    }
+                                    // or try to find if it implements a documented interface
+                                    else if (interfacedMember != null)
+                                    {
+                                        DocsTypeParam? interfacedTypeParam = interfacedMember.TypeParams.FirstOrDefault(x => x.Name == newTsTypeParam.Name || x.Name == dTypeParam.Name);
+                                        if (interfacedTypeParam != null)
+                                        {
+                                            dTypeParam.Value = interfacedTypeParam.Value;
+                                            name = interfacedTypeParam.Name;
+                                            value = interfacedTypeParam.Value;
+                                            isEII = true;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        // Attempt to port
+                        else if (!tsTypeParam.Value.IsDocsEmpty())
+                        {
+                            // try to port IntelliSense xml comments
+                            dTypeParam.Value = tsTypeParam.Value;
                             name = tsTypeParam.Name;
                             value = tsTypeParam.Value;
                         }
@@ -596,18 +648,35 @@ namespace ApiDocsSync.Libraries
                             DocsTypeParam? interfacedTypeParam = interfacedMember.TypeParams.FirstOrDefault(x => x.Name == dTypeParam.Name);
                             if (interfacedTypeParam != null)
                             {
+                                dTypeParam.Value = interfacedTypeParam.Value;
                                 name = interfacedTypeParam.Name;
                                 value = interfacedTypeParam.Value;
                                 isEII = true;
                             }
                         }
-                    }
 
-                    if (!value.IsDocsEmpty())
+
+                        if (!value.IsDocsEmpty())
+                        {
+                            PrintModifiedMember($"typeparam '{name}'", dApiToUpdate.FilePath, dApiToUpdate.DocId, isEII);
+                            TotalModifiedIndividualElements++;
+                        }
+                    }
+                }
+            }
+            else if (interfacedMember != null)
+            {
+                foreach (DocsTypeParam dTypeParam in dApiToUpdate.TypeParams)
+                {
+                    if (dTypeParam.Value.IsDocsEmpty())
                     {
-                        dTypeParam.Value = value;
-                        PrintModifiedMember($"typeparam '{name}'", dTypeParam.ParentAPI.FilePath, dApiToUpdate.DocId, isEII);
-                        TotalModifiedIndividualElements++;
+                        DocsTypeParam? interfacedTypeParam = interfacedMember.TypeParams.FirstOrDefault(x => x.Name == dTypeParam.Name);
+                        if (interfacedTypeParam != null && !interfacedTypeParam.Value.IsDocsEmpty())
+                        {
+                            dTypeParam.Value = interfacedTypeParam.Value;
+                            PrintModifiedMember($"typeparam '{dTypeParam.Name}'", dApiToUpdate.FilePath, dApiToUpdate.DocId, isEII);
+                            TotalModifiedIndividualElements++;
+                        }
                     }
                 }
             }
@@ -790,6 +859,111 @@ namespace ApiDocsSync.Libraries
                         case 2:
                             {
                                 Log.Info("Skipping this param.");
+                                break;
+                            }
+
+                        default:
+                            {
+                                Log.Error("Invalid selection. Try again.");
+                                option = -1;
+                                break;
+                            }
+                    }
+                }
+            }
+
+            return created;
+        }
+
+        // If a Param is found in a DocsType or a DocsMember that did not exist in the IntelliSense xml member, it's possible the param was unexpectedly saved in the IntelliSense xml comments with a different name, so the user gets prompted to look for it.
+        private bool TryPromptTypeParam(DocsTypeParam oldDTypeParam, IntelliSenseXmlMember tsMember, out IntelliSenseXmlTypeParam? newTsTypeParam)
+        {
+            newTsTypeParam = null;
+
+            if (Config.DisablePrompts)
+            {
+                Log.Error($"Prompts disabled. Will not process the '{oldDTypeParam.Name}' typeparam.");
+                return false;
+            }
+
+            bool created = false;
+            int option = -1;
+            while (option == -1)
+            {
+                Log.Error($"Problem in typeparam '{oldDTypeParam.Name}' in member '{tsMember.Name}' in file '{oldDTypeParam.ParentAPI.FilePath}'");
+                Log.Error($"The typeparam probably exists in code, but the exact name was not found in Docs. What would you like to do?");
+                Log.Warning("    0 - Exit program.");
+                Log.Info("    1 - Select the correct IntelliSense xml typeparam from the existing ones.");
+                Log.Info("    2 - Ignore this typeparam and continue.");
+                Log.Warning("      Note:Make sure to double check the affected Docs file after the tool finishes executing.");
+                Log.Cyan(false, "Your answer [0,1,2]: ");
+
+                if (!int.TryParse(Console.ReadLine(), out option))
+                {
+                    Log.Error("Not a number. Try again.");
+                    option = -1;
+                }
+                else
+                {
+                    switch (option)
+                    {
+                        case 0:
+                            {
+                                Log.Info("Goodbye!");
+                                Environment.Exit(0);
+                                break;
+                            }
+
+                        case 1:
+                            {
+                                int typeParamSelection = -1;
+                                while (typeParamSelection == -1)
+                                {
+                                    Log.Info($"IntelliSense xml typeparams found in member '{tsMember.Name}':");
+                                    Log.Warning("    0 - Exit program.");
+                                    Log.Info("    1 - Ignore this typeparam and continue.");
+                                    int typeParamCounter = 2;
+                                    foreach (IntelliSenseXmlTypeParam typeParam in tsMember.TypeParams)
+                                    {
+                                        Log.Info($"    {typeParamCounter} - {typeParam.Name}");
+                                        typeParamCounter++;
+                                    }
+
+                                    Log.Cyan(false, $"Your answer to match typeparam '{oldDTypeParam.Name}'? [0..{typeParamCounter - 1}]: ");
+
+                                    if (!int.TryParse(Console.ReadLine(), out typeParamSelection))
+                                    {
+                                        Log.Error("Not a number. Try again.");
+                                        typeParamSelection = -1;
+                                    }
+                                    else if (typeParamSelection < 0 || typeParamSelection >= typeParamCounter)
+                                    {
+                                        Log.Error("Invalid selection. Try again.");
+                                        typeParamSelection = -1;
+                                    }
+                                    else if (typeParamSelection == 0)
+                                    {
+                                        Log.Info("Goodbye!");
+                                        Environment.Exit(0);
+                                    }
+                                    else if (typeParamSelection == 1)
+                                    {
+                                        Log.Info("Skipping this typeparam.");
+                                        break;
+                                    }
+                                    else
+                                    {
+                                        newTsTypeParam = tsMember.TypeParams[typeParamSelection - 2];
+                                        Log.Success($"Selected: {newTsTypeParam.Name}");
+                                    }
+                                }
+
+                                break;
+                            }
+
+                        case 2:
+                            {
+                                Log.Info("Skipping this typeparam.");
                                 break;
                             }
 

--- a/src/PortToDocs/src/libraries/ToDocsPorter.cs
+++ b/src/PortToDocs/src/libraries/ToDocsPorter.cs
@@ -111,9 +111,74 @@ namespace ApiDocsSync.Libraries
             }
 
             PortMissingComments();
-            DocsComments.Save();
+        }
+
+        public void SaveToDisk() => DocsComments.SaveToDisk();
+
+        // Prints a final summary of the execution findings.
+        public void PrintSummary()
+        {
             PrintUndocumentedAPIs();
-            PrintSummary();
+
+            Log.Line();
+            Log.Info($"Total modified files: {ModifiedFiles.Count}");
+            if (Config.PrintSummaryDetails)
+            {
+                foreach (string file in ModifiedFiles)
+                {
+                    Log.Success($"    - {file}");
+                }
+                Log.Line();
+            }
+
+            Log.Info($"Total modified types: {ModifiedTypes.Count}");
+            if (Config.PrintSummaryDetails)
+            {
+                foreach (string type in ModifiedTypes)
+                {
+                    Log.Success($"    - {type}");
+                }
+                Log.Line();
+            }
+
+            Log.Info($"Total modified APIs: {ModifiedAPIs.Count}");
+            if (Config.PrintSummaryDetails)
+            {
+                foreach (string api in ModifiedAPIs)
+                {
+                    Log.Success($"    - {api}");
+                }
+            }
+
+            Log.Line();
+            Log.Info($"Total problematic APIs: {ProblematicAPIs.Count}");
+            if (Config.PrintSummaryDetails)
+            {
+                foreach (string api in ProblematicAPIs)
+                {
+                    Log.Warning($"    - {api}");
+                }
+                Log.Line();
+            }
+
+            Log.Info($"Total added exceptions: {AddedExceptions.Count}");
+            if (Config.PrintSummaryDetails)
+            {
+                foreach (string exception in AddedExceptions)
+                {
+                    Log.Success($"    - {exception}");
+                }
+                Log.Line();
+            }
+
+            Log.Info(false, "Total modified individual elements: ");
+            Log.Success($"{TotalModifiedIndividualElements}");
+
+            Log.Line();
+            Log.Success("---------");
+            Log.Success("FINISHED!");
+            Log.Success("---------");
+            Log.Line();
 
         }
 
@@ -1135,71 +1200,6 @@ namespace ApiDocsSync.Libraries
 
                 Log.Line();
             }
-        }
-
-        // Prints a final summary of the execution findings.
-        private void PrintSummary()
-        {
-            Log.Line();
-            Log.Info($"Total modified files: {ModifiedFiles.Count}");
-            if (Config.PrintSummaryDetails)
-            {
-                foreach (string file in ModifiedFiles)
-                {
-                    Log.Success($"    - {file}");
-                }
-                Log.Line();
-            }
-
-            Log.Info($"Total modified types: {ModifiedTypes.Count}");
-            if (Config.PrintSummaryDetails)
-            {
-                foreach (string type in ModifiedTypes)
-                {
-                    Log.Success($"    - {type}");
-                }
-                Log.Line();
-            }
-
-            Log.Info($"Total modified APIs: {ModifiedAPIs.Count}");
-            if (Config.PrintSummaryDetails)
-            {
-                foreach (string api in ModifiedAPIs)
-                {
-                    Log.Success($"    - {api}");
-                }
-            }
-
-            Log.Line();
-            Log.Info($"Total problematic APIs: {ProblematicAPIs.Count}");
-            if (Config.PrintSummaryDetails)
-            {
-                foreach (string api in ProblematicAPIs)
-                {
-                    Log.Warning($"    - {api}");
-                }
-                Log.Line();
-            }
-
-            Log.Info($"Total added exceptions: {AddedExceptions.Count}");
-            if (Config.PrintSummaryDetails)
-            {
-                foreach (string exception in AddedExceptions)
-                {
-                    Log.Success($"    - {exception}");
-                }
-                Log.Line();
-            }
-
-            Log.Info(false, "Total modified individual elements: ");
-            Log.Success($"{TotalModifiedIndividualElements}");
-
-            Log.Line();
-            Log.Success("---------");
-            Log.Success("FINISHED!");
-            Log.Success("---------");
-            Log.Line();
-
         }
 
         private struct MissingComments

--- a/src/PortToDocs/tests/PortToDocs/PortToDocs.FileSystem.Tests.cs
+++ b/src/PortToDocs/tests/PortToDocs/PortToDocs.FileSystem.Tests.cs
@@ -192,6 +192,7 @@ namespace ApiDocsSync.Libraries.Tests
             var porter = new ToDocsPorter(c);
             porter.CollectFiles();
             porter.Start();
+            porter.SaveToDisk();
 
             Verify(targetDir);
         }

--- a/src/PortToDocs/tests/PortToDocs/PortToDocs.FileSystem.Tests.cs
+++ b/src/PortToDocs/tests/PortToDocs/PortToDocs.FileSystem.Tests.cs
@@ -9,9 +9,9 @@ using Xunit.Abstractions;
 
 namespace ApiDocsSync.Libraries.Tests
 {
-    public class PortToDocsTests : BasePortTests
+    public class PortToDocs_FileSystem_Tests : BasePortTests
     {
-        public PortToDocsTests(ITestOutputHelper output) : base(output)
+        public PortToDocs_FileSystem_Tests(ITestOutputHelper output) : base(output)
         {
         }
 

--- a/src/PortToDocs/tests/PortToDocs/PortToDocs.Strings.Tests.cs
+++ b/src/PortToDocs/tests/PortToDocs/PortToDocs.Strings.Tests.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ApiDocsSync.Libraries.Tests
+{
+    public class PortToDocs_Strings_Tests : BasePortTests
+    {
+        public PortToDocs_Strings_Tests(ITestOutputHelper output) : base(output)
+        {
+        }
+    }
+}

--- a/src/PortToDocs/tests/PortToDocs/PortToDocs.Strings.Tests.cs
+++ b/src/PortToDocs/tests/PortToDocs/PortToDocs.Strings.Tests.cs
@@ -1,9 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.IO;
-using System.Linq;
+using System.Text;
+using System.Xml.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -13,6 +12,115 @@ namespace ApiDocsSync.Libraries.Tests
     {
         public PortToDocs_Strings_Tests(ITestOutputHelper output) : base(output)
         {
+        }
+
+        [Fact]
+        public void TypeParam_MismatchedNames_DoNotPort()
+        {
+            // The only way a typeparam is getting ported is if the name is exactly the same in the TypeParameter section as in the intellisense xml.
+            // Or, if the tool is invoked with DisabledPrompts=true.
+
+            // TypeParam name = TRenamedValue
+            string originalIntellisense = @"<?xml version=""1.0""?>
+<doc>
+  <assembly>
+    <name>MyAssembly</name>
+  </assembly>
+  <members>
+    <member name=""T:MyNamespace.MyType"">
+      <summary>This is the type summary.</summary>
+    </member>
+    <member name=""M:MyNamespace.MyType.MyTypeParamMethod``1"">
+      <typeparam name=""TRenamedValue"">The renamed typeparam of MyTypeParamMethod.</typeparam>
+      <summary>The summary of MyTypeParamMethod.</summary>
+    </member>
+  </members>
+</doc>";
+
+            // TypeParam name = TValue
+            string originalDocs = @"<Type Name=""MyType"" FullName=""MyNamespace.MyType"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=""MyTypeParamMethod&lt;TValue&gt;"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyTypeParamMethod``1"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name=""TValue"" />
+      </TypeParameters>
+      <Docs>
+        <typeparam name=""TValue"">To be added.</typeparam>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+            // TypeParam summary not ported
+            string expectedDocs = @"<Type Name=""MyType"" FullName=""MyNamespace.MyType"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>This is the type summary.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=""MyTypeParamMethod&lt;TValue&gt;"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyTypeParamMethod``1"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name=""TValue"" />
+      </TypeParameters>
+      <Docs>
+        <typeparam name=""TValue"">To be added.</typeparam>
+        <summary>The summary of MyTypeParamMethod.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+            TestWithStrings(originalIntellisense, originalDocs, expectedDocs);
+        }
+
+        private static void TestWithStrings(string originalIntellisense, string originalDocs, string expectedDocs)
+        {
+            Configuration configuration = new Configuration();
+            configuration.IncludedAssemblies.Add(TestData.TestAssembly);
+            var porter = new ToDocsPorter(configuration);
+
+            XDocument xIntellisense = XDocument.Parse(originalIntellisense);
+            porter.LoadIntellisenseXmlFile(xIntellisense, "IntelliSense.xml");
+
+            XDocument xDocs = XDocument.Parse(originalDocs);
+            var utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+            porter.LoadDocsFile(xDocs, "Docs.xml", encoding: utf8NoBom);
+
+            porter.Start();
+
+            string actualDocs = xDocs.ToString();
+            Assert.Equal(expectedDocs, actualDocs);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/api-docs-sync/issues/106

When a typeparam name is changed in triple slash, the identifier does not get updated in api docs: the old name always remains, except in the DocId.

The tool was adding extra typeparam items in the docs xmls, which is not correct. Instead, the tool should ask the user which triple slash typeparams need to be mapped to the docs typeparams. But the only condition is that the user should pass `DisablePrompts=false` to the console.

This sounds like it's also a bug on the docs side: Ideally, we should have both the old and the new names indicated in the typeparams section, but that's something we should discuss with the docs dev team.

I also added the first unit test that does not rely on the filesystem. For that, I needed to tweak the public APIs a bit: I had to take out the Save and the PrintSummary methods, and only call them in the Program.Main method, and in the old unit tests.

The new unit tests can just pass a string with the intellisense xml text, the original docs xml, and the expected docs xml.

The test I added checks that nothing is ported if there is a mismatch in typeparam names. This is because `DisabledPrompts` is `true` by default. 