### PR TITLE
Fix bug preventing markdown proper conversion of various xml elements (see, seealso, paramref, typeparamref)

### DIFF
--- a/src/PortToDocs/src/app/PortToDocs.csproj
+++ b/src/PortToDocs/src/app/PortToDocs.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
-    <Version>1.0</Version>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PortToDocs/src/libraries/XmlHelper.cs
+++ b/src/PortToDocs/src/libraries/XmlHelper.cs
@@ -33,6 +33,29 @@ namespace ApiDocsSync.Libraries
             { "></see>",        " />" }
         };
 
+        private static readonly Dictionary<string, string> _replaceableNormalElementRegexPatterns = new Dictionary<string, string>
+        {
+            // Replace primitives: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/built-in-types
+            { @"\<(see|seealso){1} cref\=""bool""[ ]*\/\>",    "<see cref=\"T:System.Boolean\" />" },
+            { @"\<(see|seealso){1} cref\=""byte""[ ]*\/\>",    "<see cref=\"T:System.Byte\" />" },
+            { @"\<(see|seealso){1} cref\=""sbyte""[ ]*\/\>",   "<see cref=\"T:System.SByte\" />" },
+            { @"\<(see|seealso){1} cref\=""char""[ ]*\/\>",    "<see cref=\"T:System.Char\" />" },
+            { @"\<(see|seealso){1} cref\=""decimal""[ ]*\/\>", "<see cref=\"T:System.Decimal\" />" },
+            { @"\<(see|seealso){1} cref\=""double""[ ]*\/\>",  "<see cref=\"T:System.Double\" />" },
+            { @"\<(see|seealso){1} cref\=""float""[ ]*\/\>",   "<see cref=\"T:System.Single\" />" },
+            { @"\<(see|seealso){1} cref\=""int""[ ]*\/\>",     "<see cref=\"T:System.Int32\" />" },
+            { @"\<(see|seealso){1} cref\=""uint""[ ]*\/\>",    "<see cref=\"T:System.UInt32\" />" },
+            { @"\<(see|seealso){1} cref\=""nint""[ ]*\/\>",    "<see cref=\"T:System.IntPtr\" />" },
+            { @"\<(see|seealso){1} cref\=""nuint""[ ]*\/\>",   "<see cref=\"T:System.UIntPtr\" />" },
+            { @"\<(see|seealso){1} cref\=""long""[ ]*\/\>",    "<see cref=\"T:System.Int64\" />" },
+            { @"\<(see|seealso){1} cref\=""ulong""[ ]*\/\>",   "<see cref=\"T:System.UInt64\" />" },
+            { @"\<(see|seealso){1} cref\=""short""[ ]*\/\>",   "<see cref=\"T:System.Int16\" />" },
+            { @"\<(see|seealso){1} cref\=""ushort""[ ]*\/\>",  "<see cref=\"T:System.UInt16\" />" },
+            { @"\<(see|seealso){1} cref\=""object""[ ]*\/\>",  "<see cref=\"T:System.Object\" />" },
+            { @"\<(see|seealso){1} cref\=""dynamic""[ ]*\/\>", "<see langword=\"dynamic\" />" },
+            { @"\<(see|seealso){1} cref\=""string""[ ]*\/\>",  "<see cref=\"T:System.String\" />" },
+        };
+
         private static readonly Dictionary<string, string> _replaceableMarkdownPatterns = new Dictionary<string, string> {
             { " null ",                      " `null` " },
             { "'null'",                      "`null`" },
@@ -64,17 +87,35 @@ namespace ApiDocsSync.Libraries
         };
 
         private static readonly Dictionary<string, string> _replaceableExceptionPatterns = new Dictionary<string, string>{
-
             { "<para>",  "\r\n" },
             { "</para>", "" }
         };
 
         private static readonly Dictionary<string, string> _replaceableMarkdownRegexPatterns = new Dictionary<string, string> {
-            { @"\<typeparamref name\=""(?'typeParamrefNameContents'[a-zA-Z0-9_\-]+)""[ ]*\/\>",  @"`${typeParamrefNameContents}`" },
-            { @"\<paramref name\=""(?'paramrefNameContents'[a-zA-Z0-9_\-]+)""[ ]*\/\>",  @"`${paramrefNameContents}`" },
+            // Replace primitives: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/built-in-types
+            { @"\<(see|seealso){1} cref\=""bool""[ ]*\/\>",    "`bool`" },
+            { @"\<(see|seealso){1} cref\=""byte""[ ]*\/\>",    "`byte`" },
+            { @"\<(see|seealso){1} cref\=""sbyte""[ ]*\/\>",   "`sbyte`" },
+            { @"\<(see|seealso){1} cref\=""char""[ ]*\/\>",    "`char`" },
+            { @"\<(see|seealso){1} cref\=""decimal""[ ]*\/\>", "`decimal`" },
+            { @"\<(see|seealso){1} cref\=""double""[ ]*\/\>",  "`double`" },
+            { @"\<(see|seealso){1} cref\=""float""[ ]*\/\>",   "`float`" },
+            { @"\<(see|seealso){1} cref\=""int""[ ]*\/\>",     "`int`" },
+            { @"\<(see|seealso){1} cref\=""uint""[ ]*\/\>",    "`uint`" },
+            { @"\<(see|seealso){1} cref\=""nint""[ ]*\/\>",    "`nint`" },
+            { @"\<(see|seealso){1} cref\=""nuint""[ ]*\/\>",   "`nuint`" },
+            { @"\<(see|seealso){1} cref\=""long""[ ]*\/\>",    "`long`" },
+            { @"\<(see|seealso){1} cref\=""ulong""[ ]*\/\>",   "`ulong`" },
+            { @"\<(see|seealso){1} cref\=""short""[ ]*\/\>",   "`short`" },
+            { @"\<(see|seealso){1} cref\=""ushort""[ ]*\/\>",  "`ushort`" },
+            { @"\<(see|seealso){1} cref\=""object""[ ]*\/\>",  "`object`" },
+            { @"\<(see|seealso){1} cref\=""dynamic""[ ]*\/\>", "`dynamic`" },
+            { @"\<(see|seealso){1} cref\=""string""[ ]*\/\>",  "`string`" },
+            // Full DocId
+            { @"\<(see|seealso){1} cref\=""([a-zA-Z0-9]{1}\:)?(?'seeContents'[a-zA-Z0-9\._\-\{\}\<\>\(\)\,\#\@\&\*\+]+)""[ ]*\/\>",      @"<xref:${seeContents}>" },
+            // Params, typeparams, langwords
+            { @"\<(typeparamref|paramref){1} name\=""(?'refNameContents'[a-zA-Z0-9_\-]+)""[ ]*\/\>",  @"`${refNameContents}`" },
             { @"\<see langword\=""(?'seeLangwordContents'[a-zA-Z0-9_\-]+)""[ ]*\/\>",  @"`${seeLangwordContents}`" },
-            { @"\<seealso cref\=""([a-zA-Z0-9]{1}\:)?(?'seeAlsoContents'.+)""[ ]*\/\>",      @"<xref:${seeAlsoContents}>" },
-            { @"\<see cref\=""([a-zA-Z0-9]{1}\:)?(?'seeCrefContents'.+)""[ ]*\/\>",      @"<xref:${seeCrefContents}>" },
         };
 
         public static string GetAttributeValue(XElement parent, string name)
@@ -149,7 +190,7 @@ namespace ApiDocsSync.Libraries
 
             XElement xeFormat = new XElement("format");
 
-            string updatedValue = SubstituteRemarksRegexPatterns(newValue);
+            string updatedValue = SubstituteRegexPatterns(newValue, _replaceableMarkdownRegexPatterns);
             updatedValue = ReplaceMarkdownPatterns(updatedValue).Trim();
 
             string remarksTitle = string.Empty;
@@ -197,6 +238,7 @@ namespace ApiDocsSync.Libraries
 
             string updatedValue = removeUndesiredEndlines ? RemoveUndesiredEndlines(newValue) : newValue;
             updatedValue = ReplaceNormalElementPatterns(updatedValue);
+            updatedValue = SubstituteRegexPatterns(updatedValue, _replaceableNormalElementRegexPatterns);
 
             // Workaround: <x> will ensure XElement does not complain about having an invalid xml object inside. Those tags will be removed by replacing the nodes.
             XElement parsedElement;
@@ -246,11 +288,6 @@ namespace ApiDocsSync.Libraries
             value = Regex.Replace(value, @"((?'undesiredEndlinePrefix'[^\.\:])(\r\n)+[ \t]*)", @"${undesiredEndlinePrefix} ");
 
             return value.Trim();
-        }
-
-        private static string SubstituteRemarksRegexPatterns(string value)
-        {
-            return SubstituteRegexPatterns(value, _replaceableMarkdownRegexPatterns);
         }
 
         private static string ReplaceMarkdownPatterns(string value)

--- a/src/PortToDocs/src/libraries/XmlHelper.cs
+++ b/src/PortToDocs/src/libraries/XmlHelper.cs
@@ -34,17 +34,6 @@ namespace ApiDocsSync.Libraries
         };
 
         private static readonly Dictionary<string, string> _replaceableMarkdownPatterns = new Dictionary<string, string> {
-            { "<see langword=\"null\"/>",    "`null`" },
-            { "<see langword=\"null\" />",   "`null`" },
-            { "<see langword=\"true\"/>",    "`true`" },
-            { "<see langword=\"true\" />",   "`true`" },
-            { "<see langword=\"false\"/>",   "`false`" },
-            { "<see langword=\"false\" />",  "`false`" },
-            { "<see cref=\"T:",              "<xref:" },
-            { "<see cref=\"F:",              "<xref:" },
-            { "<see cref=\"M:",              "<xref:" },
-            { "<see cref=\"P:",              "<xref:" },
-            { "<see cref=\"",                "<xref:" },
             { " null ",                      " `null` " },
             { "'null'",                      "`null`" },
             { " null.",                      " `null`." },
@@ -81,8 +70,11 @@ namespace ApiDocsSync.Libraries
         };
 
         private static readonly Dictionary<string, string> _replaceableMarkdownRegexPatterns = new Dictionary<string, string> {
-            { @"\<paramref name\=""(?'paramrefContents'[a-zA-Z0-9_\-]+)""[ ]*\/\>",  @"`${paramrefContents}`" },
-            { @"\<seealso cref\=""(?'seealsoContents'.+)""[ ]*\/\>",      @"seealsoContents" },
+            { @"\<typeparamref name\=""(?'typeParamrefNameContents'[a-zA-Z0-9_\-]+)""[ ]*\/\>",  @"`${typeParamrefNameContents}`" },
+            { @"\<paramref name\=""(?'paramrefNameContents'[a-zA-Z0-9_\-]+)""[ ]*\/\>",  @"`${paramrefNameContents}`" },
+            { @"\<see langword\=""(?'seeLangwordContents'[a-zA-Z0-9_\-]+)""[ ]*\/\>",  @"`${seeLangwordContents}`" },
+            { @"\<seealso cref\=""([a-zA-Z0-9]{1}\:)?(?'seeAlsoContents'.+)""[ ]*\/\>",      @"<xref:${seeAlsoContents}>" },
+            { @"\<see cref\=""([a-zA-Z0-9]{1}\:)?(?'seeCrefContents'.+)""[ ]*\/\>",      @"<xref:${seeCrefContents}>" },
         };
 
         public static string GetAttributeValue(XElement parent, string name)

--- a/src/PortToDocs/tests/PortToDocs/PortToDocs.Strings.Tests.cs
+++ b/src/PortToDocs/tests/PortToDocs/PortToDocs.Strings.Tests.cs
@@ -104,6 +104,479 @@ namespace ApiDocsSync.Libraries.Tests
             TestWithStrings(originalIntellisense, originalDocs, expectedDocs);
         }
 
+        [Fact]
+        public void See_Cref()
+        {
+            // References to other APIs, using <see cref="DocId"/> in intellisense xml, need to be transformed to <see cref="X:DocId"/> in docs xml (notice the prefix), or <xref:DocId> in markdown.
+
+            string originalIntellisense = @"<?xml version=""1.0""?>
+<doc>
+  <assembly>
+    <name>MyAssembly</name>
+  </assembly>
+  <members>
+    <member name=""T:MyNamespace.MyType"">
+      <summary>See <see cref=""T:MyNamespace.MyType""/>.</summary>
+    </member>
+    <member name=""M:MyNamespace.MyType.MyMethod"">
+      <summary>The summary of MyMethod. See <see cref=""M:MyNamespace.MyType.MyMethod"" />.</summary>
+      <remarks>See <see cref=""M:MyNamespace.MyType.MyMethod"" />.</remarks>
+    </member>
+  </members>
+</doc>";
+
+            string originalDocs = @"<Type Name=""MyType"" FullName=""MyNamespace.MyType"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=""MyMethod"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyMethod"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+            string expectedDocs = @"<Type Name=""MyType"" FullName=""MyNamespace.MyType"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>See <see cref=""T:MyNamespace.MyType"" />.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=""MyMethod"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyMethod"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>The summary of MyMethod. See <see cref=""M:MyNamespace.MyType.MyMethod"" />.</summary>
+        <remarks>
+          <format type=""text/markdown""><![CDATA[
+
+## Remarks
+
+See <xref:MyNamespace.MyType.MyMethod>.
+
+          ]]></format>
+        </remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+            TestWithStrings(originalIntellisense, originalDocs, expectedDocs);
+        }
+
+        [Fact]
+        public void SeeAlso_Cref()
+        {
+            // Normally, references to other APIs are indicated with <see cref="X:DocId"/> in xml, or with <xref:DocId> in markdown. But there are some rare cases where <seealso cref="X:DocId"/> is used, and we need to make sure to handle them just as see crefs.
+
+            string originalIntellisense = @"<?xml version=""1.0""?>
+<doc>
+  <assembly>
+    <name>MyAssembly</name>
+  </assembly>
+  <members>
+    <member name=""T:MyNamespace.MyType"">
+      <summary>See <seealso cref=""T:MyNamespace.MyType""/>.</summary>
+    </member>
+    <member name=""M:MyNamespace.MyType.MyMethod"">
+      <summary>The summary of MyMethod. See <seealso cref=""M:MyNamespace.MyType.MyMethod"" />.</summary>
+      <remarks>See <seealso cref=""M:MyNamespace.MyType.MyMethod"" />.</remarks>
+    </member>
+  </members>
+</doc>";
+
+            string originalDocs = @"<Type Name=""MyType"" FullName=""MyNamespace.MyType"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=""MyMethod"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyMethod"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+            string expectedDocs = @"<Type Name=""MyType"" FullName=""MyNamespace.MyType"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>See <seealso cref=""T:MyNamespace.MyType"" />.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=""MyMethod"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyMethod"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>The summary of MyMethod. See <seealso cref=""M:MyNamespace.MyType.MyMethod"" />.</summary>
+        <remarks>
+          <format type=""text/markdown""><![CDATA[
+
+## Remarks
+
+See <xref:MyNamespace.MyType.MyMethod>.
+
+          ]]></format>
+        </remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+            TestWithStrings(originalIntellisense, originalDocs, expectedDocs);
+        }
+
+        [Fact]
+        public void See_Langword()
+        {
+            // Reserved words are indicated with <see langword="word" />. They need to be copied as <see langword="word" /> in xml, or transformed to `word` in markdown.
+
+            string originalIntellisense = @"<?xml version=""1.0""?>
+<doc>
+  <assembly>
+    <name>MyAssembly</name>
+  </assembly>
+  <members>
+    <member name=""T:MyNamespace.MyType"">
+      <summary>Langword <see langword=""null""/>.</summary>
+    </member>
+    <member name=""M:MyNamespace.MyType.MyMethod"">
+      <summary>The summary of MyMethod. Langword <see langword=""false""/>.</summary>
+      <remarks>Langword <see langword=""true""/>.</remarks>
+    </member>
+  </members>
+</doc>";
+
+            string originalDocs = @"<Type Name=""MyType"" FullName=""MyNamespace.MyType"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=""MyMethod"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyMethod"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+            string expectedDocs = @"<Type Name=""MyType"" FullName=""MyNamespace.MyType"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>Langword <see langword=""null"" />.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=""MyMethod"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyMethod"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>The summary of MyMethod. Langword <see langword=""false"" />.</summary>
+        <remarks>
+          <format type=""text/markdown""><![CDATA[
+
+## Remarks
+
+Langword `true`.
+
+          ]]></format>
+        </remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+            TestWithStrings(originalIntellisense, originalDocs, expectedDocs);
+        }
+
+        [Fact]
+        public void ParamRefName()
+        {
+            // Parameter references are indicated with <paramref name="paramName" />. They need to be copied as <paramref name="paramName" /> in xml, or transformed to `paramName` in markdown.
+
+            string originalIntellisense = @"<?xml version=""1.0""?>
+<doc>
+  <assembly>
+    <name>MyAssembly</name>
+  </assembly>
+  <members>
+    <member name=""T:MyNamespace.MyType"">
+      <summary>Type summary.</summary>
+    </member>
+    <member name=""M:MyNamespace.MyType.MyMethod(System.String)"">
+      <summary>The summary of MyMethod. Paramref <paramref name=""myParam""/>.</summary>
+      <param name=""myParam"">My parameter description.</param>
+      <remarks>Paramref <paramref name=""myParam""/>.</remarks>
+    </member>
+  </members>
+</doc>";
+
+            string originalDocs = @"<Type Name=""MyType"" FullName=""MyNamespace.MyType"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=""MyMethod"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyMethod(System.String)"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name=""myParam"" Type=""System.String"" />
+      </Parameters>
+      <Docs>
+        <param name=""myParam"">To be added.</param>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+            string expectedDocs = @"<Type Name=""MyType"" FullName=""MyNamespace.MyType"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>Type summary.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=""MyMethod"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyMethod(System.String)"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Parameters>
+        <Parameter Name=""myParam"" Type=""System.String"" />
+      </Parameters>
+      <Docs>
+        <param name=""myParam"">My parameter description.</param>
+        <summary>The summary of MyMethod. Paramref <paramref name=""myParam"" />.</summary>
+        <remarks>
+          <format type=""text/markdown""><![CDATA[
+
+## Remarks
+
+Paramref `myParam`.
+
+          ]]></format>
+        </remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+            TestWithStrings(originalIntellisense, originalDocs, expectedDocs);
+        }
+
+        [Fact]
+        public void TypeParamRefName()
+        {
+            // TypeParameter references are indicated with <typeparamref name="typeParamName" />. They need to be copied as <typeparamref name="typeParamName" /> in xml, or transformed to `typeParamName` in markdown.
+
+            string originalIntellisense = @"<?xml version=""1.0""?>
+<doc>
+  <assembly>
+    <name>MyAssembly</name>
+  </assembly>
+  <members>
+    <member name=""T:MyNamespace.MyType`1"">
+      <typeparam name=""T"">Description of the typeparam of the type.</typeparam>
+      <summary>Type summary. Typeparamref <typeparamref name=""T""/>.</summary>
+    </member>
+    <member name=""M:MyNamespace.MyType.MyMethod``1"">
+      <summary>The summary of MyMethod. Typeparamref <typeparamref name=""T""/>.</summary>
+      <typeparam name=""T"">Description of the typeparam of the method.</typeparam>
+      <remarks>Typeparamref <typeparamref name=""T""/>.</remarks>
+    </member>
+  </members>
+</doc>";
+
+            string originalDocs = @"<Type Name=""MyType&lt;T&gt;"" FullName=""MyNamespace.MyType&lt;T&gt;"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType`1"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name=""T"">
+      <Constraints>
+        <BaseTypeName>System.ValueType</BaseTypeName>
+      </Constraints>
+    </TypeParameter>
+  </TypeParameters>
+  <Docs>
+    <typeparam name=""T"">To be added.</typeparam>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=""MyMethod&lt;T&gt;"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyMethod``1"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name=""T"">
+          <Constraints>
+            <BaseTypeName>System.ValueType</BaseTypeName>
+          </Constraints>
+        </TypeParameter>
+      </TypeParameters>
+      <Docs>
+        <typeparam name=""T"">To be added.</typeparam>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+            string expectedDocs = @"<Type Name=""MyType&lt;T&gt;"" FullName=""MyNamespace.MyType&lt;T&gt;"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType`1"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <TypeParameters>
+    <TypeParameter Name=""T"">
+      <Constraints>
+        <BaseTypeName>System.ValueType</BaseTypeName>
+      </Constraints>
+    </TypeParameter>
+  </TypeParameters>
+  <Docs>
+    <typeparam name=""T"">Description of the typeparam of the type.</typeparam>
+    <summary>Type summary. Typeparamref <typeparamref name=""T"" />.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=""MyMethod&lt;T&gt;"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyMethod``1"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <TypeParameters>
+        <TypeParameter Name=""T"">
+          <Constraints>
+            <BaseTypeName>System.ValueType</BaseTypeName>
+          </Constraints>
+        </TypeParameter>
+      </TypeParameters>
+      <Docs>
+        <typeparam name=""T"">Description of the typeparam of the method.</typeparam>
+        <summary>The summary of MyMethod. Typeparamref <typeparamref name=""T"" />.</summary>
+        <remarks>
+          <format type=""text/markdown""><![CDATA[
+
+## Remarks
+
+Typeparamref `T`.
+
+          ]]></format>
+        </remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+            TestWithStrings(originalIntellisense, originalDocs, expectedDocs);
+        }
+
         private static void TestWithStrings(string originalIntellisense, string originalDocs, string expectedDocs)
         {
             Configuration configuration = new Configuration();

--- a/src/PortToDocs/tests/PortToDocs/PortToDocs.Strings.Tests.cs
+++ b/src/PortToDocs/tests/PortToDocs/PortToDocs.Strings.Tests.cs
@@ -191,6 +191,93 @@ See <xref:MyNamespace.MyType.MyMethod>.
         }
 
         [Fact]
+        public void See_Cref_Primitive()
+        {
+            // Need to make sure that see crefs pointing to primitives are also converted properly.
+
+            string originalIntellisense = @"<?xml version=""1.0""?>
+<doc>
+  <assembly>
+    <name>MyAssembly</name>
+  </assembly>
+  <members>
+    <member name=""T:MyNamespace.MyType"">
+      <summary>Type summary.</summary>
+    </member>
+    <member name=""M:MyNamespace.MyType.MyMethod"">
+      <summary>Summary: <see cref=""bool""/>, <see cref=""byte""/>, <see cref=""sbyte""/>, <see cref=""char""/>, <see cref=""decimal""/>, <see cref=""double""/>, <see cref=""float""/>, <see cref=""int""/>, <see cref=""uint""/>, <see cref=""nint""/>, <see cref=""nuint""/>, <see cref=""long""/>, <see cref=""ulong""/>, <see cref=""short""/>, <see cref=""ushort""/>, <see cref=""object""/>, <see cref=""dynamic""/>, <see cref=""string""/>.</summary>
+      <remarks>Remarks: <see cref=""bool""/>, <see cref=""byte""/>, <see cref=""sbyte""/>, <see cref=""char""/>, <see cref=""decimal""/>, <see cref=""double""/>, <see cref=""float""/>, <see cref=""int""/>, <see cref=""uint""/>, <see cref=""nint""/>, <see cref=""nuint""/>, <see cref=""long""/>, <see cref=""ulong""/>, <see cref=""short""/>, <see cref=""ushort""/>, <see cref=""object""/>, <see cref=""dynamic""/>, <see cref=""string""/>.</remarks>
+    </member>
+  </members>
+</doc>";
+
+            string originalDocs = @"<Type Name=""MyType"" FullName=""MyNamespace.MyType"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=""MyMethod"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyMethod"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+            // Notice that `dynamic` is converted to langword, to prevent converting it to System.Object.
+            string expectedDocs = @"<Type Name=""MyType"" FullName=""MyNamespace.MyType"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>Type summary.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=""MyMethod"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyMethod"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>Summary: <see cref=""T:System.Boolean"" />, <see cref=""T:System.Byte"" />, <see cref=""T:System.SByte"" />, <see cref=""T:System.Char"" />, <see cref=""T:System.Decimal"" />, <see cref=""T:System.Double"" />, <see cref=""T:System.Single"" />, <see cref=""T:System.Int32"" />, <see cref=""T:System.UInt32"" />, <see cref=""T:System.IntPtr"" />, <see cref=""T:System.UIntPtr"" />, <see cref=""T:System.Int64"" />, <see cref=""T:System.UInt64"" />, <see cref=""T:System.Int16"" />, <see cref=""T:System.UInt16"" />, <see cref=""T:System.Object"" />, <see langword=""dynamic"" />, <see cref=""T:System.String"" />.</summary>
+        <remarks>
+          <format type=""text/markdown""><![CDATA[
+
+## Remarks
+
+Remarks: `bool`, `byte`, `sbyte`, `char`, `decimal`, `double`, `float`, `int`, `uint`, `nint`, `nuint`, `long`, `ulong`, `short`, `ushort`, `object`, `dynamic`, `string`.
+
+          ]]></format>
+        </remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+            TestWithStrings(originalIntellisense, originalDocs, expectedDocs);
+        }
+
+        [Fact]
         public void SeeAlso_Cref()
         {
             // Normally, references to other APIs are indicated with <see cref="X:DocId"/> in xml, or with <xref:DocId> in markdown. But there are some rare cases where <seealso cref="X:DocId"/> is used, and we need to make sure to handle them just as see crefs.


### PR DESCRIPTION
Fixes https://github.com/dotnet/api-docs-sync/issues/105

If a `<seealso cref="DocId"/>` is found in markdown, make sure it gets ported as `<xref:DocId>`.

Also found two closely related bugs:

- When detecting `<typeparamref name="name"/>`, need to make sure it gets converted to `name` in markdown.
- When finding a `see|seealso cref` pointing to a primitive type, need to handle them in a special way: Preserve the primitive type name in markdown, but in xml convert it to the full DocId.
 
Added individual string tests for each one of the different conversions.