### PR TITLE
Remove unused Log Help options

### DIFF
--- a/src/PortToDocs/src/libraries/Log.cs
+++ b/src/PortToDocs/src/libraries/Log.cs
@@ -228,7 +228,7 @@ Options:
     -h | -Help              no arguments        Displays this help message. If used, all other arguments are ignored and the program exits.
 
     -BinLog                 bool                Default is false (binlog file generation is disabled).
-                                                When set to true, will output a diagnostics binlog file if using '-Direction ToTripleSlash'.
+                                                When set to true, will output a diagnostics binlog file.
 
     -DisablePrompts         bool                Default is true (prompts are disabled).
                                                 Avoids prompting the user for input to correct some particular errors.
@@ -347,8 +347,7 @@ Options:
                                                         -PrintUndoc true
 
     -Save                       bool            Default is false (does not save changes).
-                                                When using -Direction ToDocs, indicates whether you want to save the Docs xml file changes.
-                                                When using -Direction ToTripleSlash, this parameter is always true, so don't specify it.
+                                                Indicates whether you want to save the Docs xml file changes.
                                                     Usage example:
                                                         -Save true
 

--- a/src/PortToTripleSlash/src/app/PortToTripleSlash.cs
+++ b/src/PortToTripleSlash/src/app/PortToTripleSlash.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using ApiDocsSync.Libraries;
 
 namespace ApiDocsSync

--- a/src/PortToTripleSlash/src/libraries/Configuration.cs
+++ b/src/PortToTripleSlash/src/libraries/Configuration.cs
@@ -23,7 +23,6 @@ namespace ApiDocsSync.Libraries
             IncludedNamespaces,
             IncludedTypes,
             Initial,
-            Save,
             SkipInterfaceImplementations,
             SkipInterfaceRemarks
         }
@@ -60,7 +59,6 @@ namespace ApiDocsSync.Libraries
         public HashSet<string> IncludedAssemblies { get; } = new HashSet<string>();
         public HashSet<string> IncludedNamespaces { get; } = new HashSet<string>();
         public HashSet<string> IncludedTypes { get; } = new HashSet<string>();
-        public bool Save { get; set; } = false;
         public bool SkipInterfaceImplementations { get; set; } = false;
         public bool SkipInterfaceRemarks { get; set; } = true;
 
@@ -310,10 +308,6 @@ namespace ApiDocsSync.Libraries
                                     mode = Mode.IncludedTypes;
                                     break;
 
-                                case "-SAVE":
-                                    mode = Mode.Save;
-                                    break;
-
                                 case "-SKIPINTERFACEIMPLEMENTATIONS":
                                     mode = Mode.SkipInterfaceImplementations;
                                     break;
@@ -326,13 +320,6 @@ namespace ApiDocsSync.Libraries
                                     Log.ErrorAndExit($"Unrecognized argument: {arg}");
                                     break;
                             }
-                            break;
-                        }
-
-                    case Mode.Save:
-                        {
-                            config.Save = ParseOrExit(arg, "Save");
-                            mode = Mode.Initial;
                             break;
                         }
 

--- a/src/PortToTripleSlash/src/libraries/Docs/DocsCommentsContainer.cs
+++ b/src/PortToTripleSlash/src/libraries/Docs/DocsCommentsContainer.cs
@@ -40,16 +40,6 @@ namespace ApiDocsSync.Libraries.Docs
 
         public void Save()
         {
-            if (!Config.Save)
-            {
-                Log.Line();
-                Log.Error("[No files were saved]");
-                Log.Warning($"Did you forget to specify '-{nameof(Config.Save)} true'?");
-                Log.Line();
-
-                return;
-            }
-
             List<string> savedFiles = new();
             foreach (var type in Types.Values.Where(x => x.Changed))
             {

--- a/src/PortToTripleSlash/src/libraries/Log.cs
+++ b/src/PortToTripleSlash/src/libraries/Log.cs
@@ -224,7 +224,7 @@ Options:
     -h | -Help              no arguments        Displays this help message. If used, all other arguments are ignored and the program exits.
 
     -BinLog                 bool                Default is false (binlog file generation is disabled).
-                                                When set to true, will output a diagnostics binlog file if using '-Direction ToTripleSlash'.
+                                                When set to true, will output a diagnostics binlog file.
 
     -ExcludedAssemblies     string list         Default is empty (does not ignore any assemblies/namespaces).
                                                 Comma separated list (no spaces) of specific .NET assemblies/namespaces to ignore.
@@ -250,12 +250,6 @@ Options:
                                                 Comma separated list (no spaces) of specific types to include.
                                                     Usage example:
                                                         -IncludedTypes FileStream,DirectoryInfo
-
-    -Save                       bool            Default is false (does not save changes).
-                                                When using -Direction ToDocs, indicates whether you want to save the Docs xml file changes.
-                                                When using -Direction ToTripleSlash, this parameter is always true, so don't specify it.
-                                                    Usage example:
-                                                        -Save true
 
     -SkipInterfaceImplementations       bool    Default is false (includes interface implementations).
                                                 Whether you want the original interface documentation to be considered to fill the
@@ -284,7 +278,6 @@ Options:
 
         Example:
             PortToTripleSlash \
-                -Direction ToTripleSlash \
                 -CsProj D:\runtime\src\libraries\System.IO.Compression.Brotli\src\System.IO.Compression.Brotli.csproj \
                 -Docs D:\dotnet-api-docs\xml \
                 -IncludedAssemblies System.IO.Compression.Brotli \

--- a/src/PortToTripleSlash/tests/PortToTripleSlash/PortToTripleSlashTests.cs
+++ b/src/PortToTripleSlash/tests/PortToTripleSlash/PortToTripleSlashTests.cs
@@ -43,7 +43,6 @@ namespace ApiDocsSync.Libraries.Tests
             Configuration c = new()
             {
                 CsProj = new FileInfo(testData.ProjectFilePath),
-                Save = save,
                 SkipInterfaceImplementations = skipInterfaceImplementations
             };
 


### PR DESCRIPTION
After splitting the two tools, I realized I left some help strings and config options that do not belong anymore.

Also added a missing copyright header.