### PR TITLE
Fix Triple Slash Porter MSBuild loading

### DIFF
--- a/src/PortToTripleSlash/src/app/PortToTripleSlash.csproj
+++ b/src/PortToTripleSlash/src/app/PortToTripleSlash.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <StartupObject>ApiDocsSync.PortToTripleSlash</StartupObject>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
-    <Version>1.0</Version>
+    <Version>1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PortToTripleSlash/src/libraries/Docs/DocsType.cs
+++ b/src/PortToTripleSlash/src/libraries/Docs/DocsType.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Xml.Linq;
+using Microsoft.CodeAnalysis;
 
 namespace ApiDocsSync.Libraries.Docs
 {
@@ -32,6 +33,8 @@ namespace ApiDocsSync.Libraries.Docs
             FileEncoding = encoding;
             AssemblyInfos.AddRange(XERoot.Elements("AssemblyInfo").Select(x => new DocsAssemblyInfo(x)));
         }
+
+        public List<ResolvedLocation>? SymbolLocations { get; set; }
 
         public XDocument XDoc { get; set; }
 

--- a/src/PortToTripleSlash/src/libraries/Log.cs
+++ b/src/PortToTripleSlash/src/libraries/Log.cs
@@ -223,8 +223,8 @@ Options:
 
     -h | -Help              no arguments        Displays this help message. If used, all other arguments are ignored and the program exits.
 
-    -BinLog                 bool                Default is false (binlog file generation is disabled).
-                                                When set to true, will output a diagnostics binlog file.
+    -BinLogPath             string              Default is null (binlog file generation is disabled).
+                                                When set to a valid path, will output a diagnostics binlog to that location.
 
     -ExcludedAssemblies     string list         Default is empty (does not ignore any assemblies/namespaces).
                                                 Comma separated list (no spaces) of specific .NET assemblies/namespaces to ignore.
@@ -250,6 +250,9 @@ Options:
                                                 Comma separated list (no spaces) of specific types to include.
                                                     Usage example:
                                                         -IncludedTypes FileStream,DirectoryInfo
+
+    -IsMono                 bool                Default is false.
+                                                When set to true, the main project passed with -CsProj is assumed to be a mono project.
 
     -SkipInterfaceImplementations       bool    Default is false (includes interface implementations).
                                                 Whether you want the original interface documentation to be considered to fill the

--- a/src/PortToTripleSlash/src/libraries/MSBuildLoader.cs
+++ b/src/PortToTripleSlash/src/libraries/MSBuildLoader.cs
@@ -1,0 +1,222 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.MSBuild;
+using Microsoft.Build.Logging;
+using System.IO;
+
+namespace ApiDocsSync.Libraries
+{
+    // Per the documentation: https://docs.microsoft.com/en-us/visualstudio/msbuild/updating-an-existing-application
+    // Do not call any of these APIs from the same context where MSBuildLocator is being called.
+    public class MSBuildLoader
+    {
+        private const string AllowedWarningMessage = "Found project reference without a matching metadata reference";
+
+        private readonly Dictionary<string, string> _monoWorkspaceProperties = new() { { "RuntimeFlavor", "Mono" } };
+
+        private BinaryLogger? _binLog = null;
+        public BinaryLogger? BinLog
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(BinLogPath))
+                {
+                    if (_binLog == null)
+                    {
+                        Log.Info($"Enabling the collection of a binlog file: {BinLogPath}");
+                        _binLog = new BinaryLogger()
+                        {
+                            Parameters = Path.Combine(Environment.CurrentDirectory, BinLogPath),
+                            Verbosity = LoggerVerbosity.Diagnostic,
+                            CollectProjectImports = BinaryLogger.ProjectImportsCollectionMode.Embed
+                        };
+                    }
+                }
+
+                return _binLog;
+            }
+        }
+
+        public string? BinLogPath { get; private set; }
+
+        public List<ResolvedWorkspace> ResolvedWorkspaces { get; private set; } = new();
+
+        public ResolvedProject? MainProject { get; private set; }
+
+        public MSBuildLoader(string? binLogPath)
+        {
+            BinLogPath = binLogPath;
+        }
+
+        public async Task LoadMainProjectAsync(string projectPath, bool isMono, CancellationToken cancellationToken)
+        {
+            MainProject = await LoadProjectAsync(projectPath, isMono, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<ResolvedProject> LoadProjectAsync(string projectPath, bool isMono, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Debug.Assert(projectPath != null);
+            if (!TryGetResolvedWorkspace(projectPath, isMono, out ResolvedWorkspace? resolvedWorkspace))
+            {
+                throw new Exception("Workspace not created.");
+            }
+            ThrowIfDiagnosticsFound(resolvedWorkspace, $"MSBuildWorkspace.Create - {projectPath}", isMono);
+
+            ResolvedProject? resolvedProject = await TryGetResolvedProjectAsync(resolvedWorkspace, projectPath, cancellationToken).ConfigureAwait(false);
+            if (resolvedProject == null)
+            {
+                throw new Exception("Project not created.");
+            }
+            ThrowIfDiagnosticsFound(resolvedWorkspace, $"Project.OpenProjectAsync - {projectPath}", isMono);
+
+            return resolvedProject;
+        }
+
+        private bool TryGetResolvedWorkspace(string projectPath, bool isMono, [NotNullWhen(returnValue: true)] out ResolvedWorkspace? resolvedWorkspace)
+        {
+            ResolvedProject? resolvedProject = FindResolvedProjectInResolvedWorkspaces(projectPath);
+
+            if (resolvedProject == null)
+            {
+                Log.Info($"Did not find an existing resolved project for path {projectPath}{(isMono ? " (Mono)" : "")}. Creating a workspace for it...");
+                MSBuildWorkspace msBuildWorkspace = isMono ? MSBuildWorkspace.Create(_monoWorkspaceProperties) : MSBuildWorkspace.Create();
+                msBuildWorkspace.AssociateFileExtensionWithLanguage("ilproj", LanguageNames.CSharp);
+                resolvedWorkspace = new ResolvedWorkspace(msBuildWorkspace);
+                ResolvedWorkspaces.Add(resolvedWorkspace);
+            }
+            else
+            {
+                Log.Info($"Found existing resolved project for path {projectPath}. Returning its workspace...");
+                resolvedWorkspace = resolvedProject.ResolvedWorkspace;
+            }
+
+            return resolvedWorkspace != null;
+        }
+
+        private ResolvedProject? FindResolvedProjectInResolvedWorkspaces(string projectPath)
+        {
+            Log.Info($"Looking for a resolved workspace that contains the project '{projectPath}'...");
+            foreach (ResolvedWorkspace resolvedWorkspace in ResolvedWorkspaces)
+            {
+                foreach (ResolvedProject resolvedProject in resolvedWorkspace.ResolvedProjects)
+                {
+                    if (resolvedProject.Project.FilePath == projectPath)
+                    {
+                        return resolvedProject;
+                    }
+                }
+            }
+            return null;
+        }
+
+        private async Task<ResolvedProject?> TryGetResolvedProjectAsync(ResolvedWorkspace resolvedWorkspace, string projectPath,  CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Log.Info($"Looking for a resolved project that contains the project '{projectPath}'...");
+            ResolvedProject? resolvedProject = resolvedWorkspace.ResolvedProjects.SingleOrDefault(p => p.Project.FilePath == projectPath);
+            if (resolvedProject == null)
+            {
+                Log.Info($"Did not find an existing resolved project for path '{projectPath}'. Attempting to find the project in this workspace...");
+                Project project = await resolvedWorkspace.Workspace.OpenProjectAsync(projectPath, BinLog, cancellationToken: cancellationToken).ConfigureAwait(false);
+                if (project != null)
+                {
+                    Log.Info($"Found the project in this workspace. Attempting to get compilation...");
+                    Compilation? compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+
+                    if (compilation != null)
+                    {
+                        Log.Info($"Found the compilation for this project. Creating the resolved project...");
+                        resolvedProject = new ResolvedProject(resolvedWorkspace, project, compilation);
+                        resolvedWorkspace.ResolvedProjects.Add(resolvedProject);
+                    }
+                    else
+                    {
+                        Log.Error($"Did not find a compilation for this project.");
+                    }
+                }
+                else
+                {
+                    Log.Error($"Could not find the project in this workspace.");
+                }
+            }
+
+            return resolvedProject;
+        }
+
+        private static void ThrowIfDiagnosticsFound(ResolvedWorkspace resolvedWorkspace, string origin, bool isMono)
+        {
+            if (resolvedWorkspace.Workspace.Diagnostics.Any())
+            {
+                List<string> throwableErrors = new();
+
+                foreach (WorkspaceDiagnostic diagnostic in resolvedWorkspace.Workspace.Diagnostics)
+                {
+                    if (!diagnostic.Message.Contains(AllowedWarningMessage))
+                    {
+                        throwableErrors.Add($"    {diagnostic.Kind} - {diagnostic.Message}");
+                    }
+                }
+
+                if (throwableErrors.Any())
+                {
+                    string message = $"{(isMono ? "Mono:" : "")}{Environment.NewLine}{origin}{Environment.NewLine}{string.Join(Environment.NewLine, throwableErrors)}";
+                    throw new Exception(message);
+                }
+            }
+        }
+    }
+
+    public class ResolvedWorkspace
+    {
+        public MSBuildWorkspace Workspace { get; private set; }
+        public List<ResolvedProject> ResolvedProjects { get; }
+        public ResolvedWorkspace(MSBuildWorkspace workspace)
+        {
+            Workspace = workspace;
+            ResolvedProjects = new List<ResolvedProject>();
+        }
+    }
+
+    public class ResolvedProject
+    {
+        public ResolvedWorkspace ResolvedWorkspace { get; private set; }
+        public Project Project { get; private set; }
+        public Compilation Compilation { get; private set; }
+        public ResolvedProject(ResolvedWorkspace resolvedWorkspace, Project project, Compilation compilation)
+        {
+            ResolvedWorkspace = resolvedWorkspace;
+            Project = project;
+            Compilation = compilation;
+        }
+    }
+
+    public class ResolvedLocation
+    {
+        public string TypeName { get; private set; }
+        public ResolvedProject ResolvedProject { get; private set; }
+        public Location Location { get; private set; }
+        public SyntaxTree Tree { get; set; }
+        public SemanticModel Model { get; set; }
+        public ResolvedLocation(string typeName, ResolvedProject resolvedProject, Location location, SyntaxTree tree)
+        {
+            TypeName = typeName;
+            ResolvedProject = resolvedProject;
+            Location = location;
+            Tree = tree;
+            Model = resolvedProject.Compilation.GetSemanticModel(Tree);
+        }
+    }
+}

--- a/src/PortToTripleSlash/src/libraries/ToTripleSlashPorter.cs
+++ b/src/PortToTripleSlash/src/libraries/ToTripleSlashPorter.cs
@@ -49,29 +49,26 @@ namespace ApiDocsSync.Libraries
             }
         }
 
-        private readonly Configuration Config;
-        private readonly DocsCommentsContainer DocsComments;
+        private readonly Configuration _config;
+        private readonly DocsCommentsContainer _docsComments;
 
-#pragma warning disable RS1024 // Compare symbols correctly
-        // Bug fixed https://github.com/dotnet/roslyn-analyzers/pull/4571
-        private readonly Dictionary<string, LocationInformation> ResolvedLocations = new();
-#pragma warning restore RS1024 // Compare symbols correctly
+        private readonly Dictionary<string, LocationInformation> _resolvedLocations = new();
 
-        private const string _allowedWarningMessage = "Found project reference without a matching metadata reference";
-        private static readonly string _pathSrcCoreclr = Path.Combine("src", "coreclr");
+        private const string AllowedWarningMessage = "Found project reference without a matching metadata reference";
+        private static readonly string s_pathSrcCoreclr = Path.Combine("src", "coreclr");
 
-        private static readonly string SystemPrivateCoreLib = "SYSTEM.PRIVATE.CORELIB";
+        private static readonly string s_systemPrivateCoreLib = "SYSTEM.PRIVATE.CORELIB";
 
-        private static readonly Dictionary<string, string> WorkspaceProperties = new() { { "RuntimeFlavor", "Mono" } };
+        private static readonly Dictionary<string, string> s_workspaceProperties = new() { { "RuntimeFlavor", "Mono" } };
 
-        private static readonly Dictionary<string, MSBuildWorkspace> Workspaces = new();
-        private static readonly Dictionary<string, MSBuildWorkspace> WorkspacesMono = new();
+        private static readonly Dictionary<string, MSBuildWorkspace> s_workspaces = new();
+        private static readonly Dictionary<string, MSBuildWorkspace> s_workspacesMono = new();
 
-        private static readonly Dictionary<string, Project> Projects = new();
-        private static readonly Dictionary<string, Compilation> Compilations = new();
+        private static readonly Dictionary<string, Project> s_projects = new();
+        private static readonly Dictionary<string, Compilation> s_compilations = new();
 
-        private static readonly Dictionary<string, Project> ProjectsMono = new();
-        private static readonly Dictionary<string, Compilation> CompilationsMono = new();
+        private static readonly Dictionary<string, Project> s_projectsMono = new();
+        private static readonly Dictionary<string, Compilation> s_compilationsMono = new();
 
         // If enabled via CLI arguments, a binlog file will be generated when running this tool.
         BinaryLogger? _binLogger = null;
@@ -79,14 +76,14 @@ namespace ApiDocsSync.Libraries
         {
             get
             {
-                if (Config.BinLogger)
+                if (_config.BinLogger)
                 {
                     if (_binLogger == null)
                     {
                         Log.Info("Enabling the collection of a binlog file...");
                         _binLogger = new BinaryLogger()
                         {
-                            Parameters = Path.Combine(Environment.CurrentDirectory, Config.BinLogPath),
+                            Parameters = Path.Combine(Environment.CurrentDirectory, _config.BinLogPath),
                             Verbosity = Microsoft.Build.Framework.LoggerVerbosity.Diagnostic,
                             CollectProjectImports = BinaryLogger.ProjectImportsCollectionMode.Embed
                         };
@@ -100,8 +97,8 @@ namespace ApiDocsSync.Libraries
         // Initializes a new porter instance with the specified configuration.
         private ToTripleSlashPorter(Configuration config)
         {
-            Config = config;
-            DocsComments = new DocsCommentsContainer(config);
+            _config = config;
+            _docsComments = new DocsCommentsContainer(config);
         }
 
         /// <summary>
@@ -120,15 +117,15 @@ namespace ApiDocsSync.Libraries
             // IMPORTANT: Need to load the MSBuild property BEFORE calling the ToTripleSlashPorter constructor.
             LoadVSInstance();
 
-            var porter = new ToTripleSlashPorter(config);
+            ToTripleSlashPorter porter = new(config);
             porter.Port();
         }
 
         // Collects the Docs xml files, the source code files, and ports the xml comments to triple slash.
         private void Port()
         {
-            DocsComments.CollectFiles();
-            if (!DocsComments.Types.Any())
+            _docsComments.CollectFiles();
+            if (!_docsComments.Types.Any())
             {
                 Log.Error("No Docs Type APIs found. Is the Docs xml path correct? Exiting.");
                 Environment.Exit(0);
@@ -136,30 +133,30 @@ namespace ApiDocsSync.Libraries
             Log.Info("Reading source code projects...");
 
             // Load and store the main project
-            ProjectInformation mainProjectInfo = GetProjectInfo(Config.CsProj!.FullName, isMono: false);
+            ProjectInformation mainProjectInfo = GetProjectInfo(_config.CsProj!.FullName, isMono: false);
 
-            foreach (DocsType docsType in DocsComments.Types.Values)
+            foreach (DocsType docsType in _docsComments.Types.Values)
             {
                 // If the symbol is not found in the current compilation, nothing to do - It means the Docs
                 // for APIs from an unrelated namespace were loaded for this compilation's assembly
                 if (!TryGetNamedSymbol(mainProjectInfo.Compilation, docsType.TypeName, out INamedTypeSymbol? symbol))
                 {
-                    Log.Info($"Type symbol '{docsType.FullName}' not found in compilation for '{Config.CsProj.FullName}'.");
+                    Log.Info($"Type symbol '{docsType.FullName}' not found in compilation for '{_config.CsProj.FullName}'.");
                     continue;
                 }
 
                 // Make sure at least one syntax tree of this symbol can be found in the current project's compilation
                 if (!symbol.Locations.Any())
                 {
-                    throw new NullReferenceException($"The symbol for the type '{docsType.FullName}' had no locations in '{Config.CsProj.FullName}'.");
+                    throw new NullReferenceException($"The symbol for the type '{docsType.FullName}' had no locations in '{_config.CsProj.FullName}'.");
                 }
 
-                Log.Cyan($"Type symbol '{docsType.FullName}' found in compilation for '{Config.CsProj.FullName}'.");
+                Log.Cyan($"Type symbol '{docsType.FullName}' found in compilation for '{_config.CsProj.FullName}'.");
 
                 // Otherwise, port the exact same comments in each location
                 AddSymbolLocationsToResolvedLocations(mainProjectInfo, symbol, docsType);
 
-                Log.Info($"Also trying to find '{symbol.Name}' in the referenced projects of project '{Config.CsProj.FullName}'...");
+                Log.Info($"Also trying to find '{symbol.Name}' in the referenced projects of project '{_config.CsProj.FullName}'...");
                 FindSymbolInReferencedProjects(docsType, mainProjectInfo.Project.ProjectReferences);
             }
 
@@ -175,13 +172,13 @@ namespace ApiDocsSync.Libraries
                 if (IsLocationTreeInCompilationTrees(location, projectInfo.Compilation))
                 {
                     Log.Info($"Symbol '{symbol.Name}' found in location '{path}'.");
-                    var info = new LocationInformation(docsType, location, projectInfo.Compilation);
+                    LocationInformation info = new(docsType, location, projectInfo.Compilation);
                     AddToResolvedSymbols(info);
                 }
                 else
                 {
                     Log.Info(false, $"Symbol '{symbol.Name}' not found in locations of project '{path}'.");
-                    if (n < symbol.Locations.Count())
+                    if (n < symbol.Locations.Length)
                     {
                         Log.Info(true, " Trying the next location...");
                     }
@@ -203,14 +200,14 @@ namespace ApiDocsSync.Libraries
 
                 // Skip looking in projects whose namespace that were explicitly excluded or not explicitly included
                 // The only exception is System.Private.CoreLib, which we should always explore
-                if (projectNamespaceToUpper != SystemPrivateCoreLib)
+                if (projectNamespaceToUpper != s_systemPrivateCoreLib)
                 {
-                    if (Config.ExcludedNamespaces.Any(x => x.StartsWith(projectNamespace)))
+                    if (_config.ExcludedNamespaces.Any(x => x.StartsWith(projectNamespace)))
                     {
                         Log.Info($"Skipping project '{projectPath}' which was added to -ExcludedNamespaces.");
                         continue;
                     }
-                    else if (!Config.IncludedNamespaces.Any(x => x.StartsWith(projectNamespace)))
+                    else if (!_config.IncludedNamespaces.Any(x => x.StartsWith(projectNamespace)))
                     {
                         Log.Info($"Skipping project '{projectPath}' which was not added to -IncludedNamespaces.");
                         continue;
@@ -228,8 +225,8 @@ namespace ApiDocsSync.Libraries
                     string monoProjectPath = Regex.Replace(projectPath, @"src(?<separator>[\\\/]{1})coreclr", "src${separator}mono");
 
                     // If the symbol was found in corelib, try to also find it in mono
-                    if (projectNamespaceToUpper == SystemPrivateCoreLib &&
-                        projectPath.Contains(_pathSrcCoreclr) &&
+                    if (projectNamespaceToUpper == s_systemPrivateCoreLib &&
+                        projectPath.Contains(s_pathSrcCoreclr) &&
                         TryFindSymbolInReferencedProject(monoProjectPath, docsType.TypeName, isMono: true, out ProjectInformation? monoProjectInfo, out INamedTypeSymbol? monoSymbol))
                     {
                         Log.Info($"Symbol '{monoSymbol.Name}' was also found in Mono locations of project '{monoProjectInfo.Project.FilePath}'.");
@@ -259,7 +256,7 @@ namespace ApiDocsSync.Libraries
         private void AddToResolvedSymbols(LocationInformation info)
         {
             string key = info.Tree.FilePath; // This ensures we have a unique key for symbols that are also found in mono
-            if (!ResolvedLocations.TryAdd(key, info))
+            if (!_resolvedLocations.TryAdd(key, info))
             {
                 Log.Info($"Skipping symbol tree already added for '{key}'.");
             }
@@ -287,10 +284,10 @@ namespace ApiDocsSync.Libraries
         private void PortDocsForResolvedSymbols()
         {
             Log.Info("Porting comments from Docs to triple slash...");
-            foreach ((string filePath, LocationInformation info) in ResolvedLocations)
+            foreach ((string filePath, LocationInformation info) in _resolvedLocations)
             {
                 Log.Info($"Porting docs for '{filePath}'...");
-                TripleSlashSyntaxRewriter rewriter = new(DocsComments, info.Model);
+                TripleSlashSyntaxRewriter rewriter = new(_docsComments, info.Model);
                 SyntaxNode newRoot = rewriter.Visit(info.Tree.GetRoot())
                     ?? throw new NullReferenceException($"Returned null root node for {info.Api.FullName} in {info.Tree.FilePath}");
 
@@ -357,22 +354,22 @@ namespace ApiDocsSync.Libraries
         private ProjectInformation GetProjectInfo(string projectPath, bool isMono)
         {
             MSBuildWorkspace workspace = GetOrAddWorkspace(
-                isMono ? WorkspacesMono : Workspaces,
-                isMono ? WorkspaceProperties : null,
+                isMono ? s_workspacesMono : s_workspaces,
+                isMono ? s_workspaceProperties : null,
                 projectPath);
 
             Project project = GetOrAddProject(
                 workspace,
-                isMono ? ProjectsMono : Projects,
+                isMono ? s_projectsMono : s_projects,
                 projectPath);
 
             Compilation compilation = GetOrAddCompilation(
                 workspace,
                 project,
-                isMono ? CompilationsMono : Compilations,
+                isMono ? s_compilationsMono : s_compilations,
                 projectPath);
 
-            var pd = new ProjectInformation(project, compilation, isMono);
+            ProjectInformation pd = new(project, compilation, isMono);
 
             return pd;
         }
@@ -449,11 +446,11 @@ namespace ApiDocsSync.Libraries
             ImmutableList<WorkspaceDiagnostic> diagnostics = workspace.Diagnostics;
             if (diagnostics.Any())
             {
-                var allMsgs = new List<string>();
+                List<string> allMsgs = new();
 
-                foreach (var diagnostic in diagnostics)
+                foreach (WorkspaceDiagnostic diagnostic in diagnostics)
                 {
-                    if (!diagnostic.Message.Contains(_allowedWarningMessage))
+                    if (!diagnostic.Message.Contains(AllowedWarningMessage))
                     {
                         allMsgs.Add($"    {diagnostic.Kind} - {diagnostic.Message}");
                     }
@@ -486,11 +483,11 @@ namespace ApiDocsSync.Libraries
         // Loads the external VS instance using the correct MSBuild dependency, which differs from the one used by this process.
         public static VisualStudioInstance LoadVSInstance()
         {
-            var vsBuildInstances = MSBuildLocator.QueryVisualStudioInstances().ToArray();
+            VisualStudioInstance[] vsBuildInstances = MSBuildLocator.QueryVisualStudioInstances().ToArray();
 
-            // https://github.com/carlossanlop/ApiDocsSync/issues/69
+            // https://github.com/dotnet/api-docs-sync/issues/69
             // Prefer the latest stable instance if there is one
-            var instance = vsBuildInstances
+            VisualStudioInstance instance = vsBuildInstances
                 .Where(b => !b.MSBuildPath.Contains("-preview")).OrderByDescending(b => b.Version).FirstOrDefault() ??
                 vsBuildInstances.First();
 
@@ -512,17 +509,17 @@ namespace ApiDocsSync.Libraries
             {
                 lock (s_guard)
                 {
-                    if (s_namesToAssemblies.TryGetValue(assemblyName.FullName, out var cachedAssembly))
+                    if (s_namesToAssemblies.TryGetValue(assemblyName.FullName, out Assembly? cachedAssembly))
                     {
                         return cachedAssembly;
                     }
 
-                    var assembly = TryResolveAssemblyFromPaths(context, assemblyName, searchPath, s_pathsToAssemblies);
+                    Assembly? assembly = TryResolveAssemblyFromPaths(context, assemblyName, searchPath, s_pathsToAssemblies);
 
                     // Cache assembly
                     if (assembly != null)
                     {
-                        var name = assembly.FullName;
+                        string? name = assembly.FullName;
                         if (name is null)
                         {
                             throw new Exception($"Could not get name for assembly '{assembly}'");
@@ -540,7 +537,7 @@ namespace ApiDocsSync.Libraries
         // Tries to find and return the specified assembly by looking in all the known locations where it could be found.
         private static Assembly? TryResolveAssemblyFromPaths(AssemblyLoadContext context, AssemblyName assemblyName, string searchPath, Dictionary<string, Assembly>? knownAssemblyPaths = null)
         {
-            foreach (var cultureSubfolder in string.IsNullOrEmpty(assemblyName.CultureName)
+            foreach (string? cultureSubfolder in string.IsNullOrEmpty(assemblyName.CultureName)
                 // If no culture is specified, attempt to load directly from
                 // the known dependency paths.
                 ? new[] { string.Empty }
@@ -549,17 +546,17 @@ namespace ApiDocsSync.Libraries
                 // bare search directory if that fails.
                 : new[] { assemblyName.CultureName, string.Empty })
             {
-                foreach (var extension in new[] { "ni.dll", "ni.exe", "dll", "exe" })
+                foreach (string? extension in new[] { "ni.dll", "ni.exe", "dll", "exe" })
                 {
-                    var candidatePath = Path.Combine(searchPath, cultureSubfolder, $"{assemblyName.Name}.{extension}");
+                    string candidatePath = Path.Combine(searchPath, cultureSubfolder, $"{assemblyName.Name}.{extension}");
 
-                    var isAssemblyLoaded = knownAssemblyPaths?.ContainsKey(candidatePath) == true;
+                    bool isAssemblyLoaded = knownAssemblyPaths?.ContainsKey(candidatePath) == true;
                     if (isAssemblyLoaded || !File.Exists(candidatePath))
                     {
                         continue;
                     }
 
-                    var candidateAssemblyName = AssemblyLoadContext.GetAssemblyName(candidatePath);
+                    AssemblyName candidateAssemblyName = AssemblyLoadContext.GetAssemblyName(candidatePath);
                     if (candidateAssemblyName.Version < assemblyName.Version)
                     {
                         continue;
@@ -567,7 +564,7 @@ namespace ApiDocsSync.Libraries
 
                     try
                     {
-                        var assembly = context.LoadFromAssemblyPath(candidatePath);
+                        Assembly assembly = context.LoadFromAssemblyPath(candidatePath);
                         return assembly;
                     }
                     catch

--- a/src/PortToTripleSlash/src/libraries/VSLoader.cs
+++ b/src/PortToTripleSlash/src/libraries/VSLoader.cs
@@ -1,0 +1,146 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.Build.Locator;
+
+namespace ApiDocsSync.Libraries
+{
+    // Per the documentation: https://docs.microsoft.com/en-us/visualstudio/msbuild/updating-an-existing-application
+    // Do not call any of these APIs from the same context where Microsoft.Build APIs are being called.
+    public static class VSLoader
+    {
+        private static readonly string[] s_candidateExtensions = new[] { "ni.dll", "ni.exe", "dll", "exe" };
+        private static readonly Dictionary<string, Assembly> s_pathsToAssemblies = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, Assembly> s_namesToAssemblies = new();
+        private static readonly object s_guard = new();
+
+        public static VisualStudioInstance? VSInstance { get; private set; }
+
+        // Per the documentation: https://docs.microsoft.com/en-us/visualstudio/msbuild/updating-an-existing-application
+        // Cannot reference any MSBuild types (from Microsoft.Build namespace) in the same method that calls MSBuildLocator.
+        public static void LoadVSInstance()
+        {
+            Log.Info("Querying for all Visual Studio instances...");
+            IEnumerable<VisualStudioInstance> vsBuildInstances = MSBuildLocator.QueryVisualStudioInstances();
+
+            if (!vsBuildInstances.Any())
+            {
+                throw new Exception("No VS instances found.");
+            }
+
+            Log.Info("Looking for the latest stable instance of Visual Studio, if there is one...");
+            VSInstance = vsBuildInstances.Where(b => !b.MSBuildPath.Contains("-preview"))
+                                         .OrderByDescending(b => b.Version)
+                                         .FirstOrDefault() ??
+                         vsBuildInstances.First();
+            Log.Success($"Selected instance:{Environment.NewLine}  - MSBuildPath: {VSInstance.MSBuildPath}{Environment.NewLine}  - Version: {VSInstance.Version}");
+
+            // Unit tests execute this multiple times, ensure we only register once
+            if (MSBuildLocator.CanRegister)
+            {
+                Log.Info("Attempting to register assembly loader...");
+                RegisterAssemblyLoader(VSInstance.MSBuildPath);
+                Log.Info("Attempting to register Visual Studio instance");
+                MSBuildLocator.RegisterInstance(VSInstance);
+                Log.Success("Successful Visual Studio load!");
+            }
+            else
+            {
+                Log.Error("Could not register the Visual Studio instance (CanRegister=false).");
+            }
+        }
+
+        // Register an assembly loader that will load assemblies with higher version than what was requested.
+        private static void RegisterAssemblyLoader(string searchPath)
+        {
+            AssemblyLoadContext.Default.Resolving += (AssemblyLoadContext context, AssemblyName assemblyName) =>
+            {
+                lock (s_guard)
+                {
+                    if (s_namesToAssemblies.TryGetValue(assemblyName.FullName, out Assembly? cachedAssembly))
+                    {
+                        return cachedAssembly;
+                    }
+
+                    if (TryResolveAssemblyFromPaths(context, assemblyName, searchPath, out Assembly? assembly))
+                    {
+                        // Cache assembly
+                        string? name = assembly.FullName;
+                        if (name is null)
+                        {
+                            throw new Exception($"Could not get name for assembly '{assembly}'");
+                        }
+
+                        s_pathsToAssemblies[assembly.Location] = assembly;
+                        s_namesToAssemblies[name] = assembly;
+
+                        return assembly;
+                    }
+
+                    return null;
+                }
+            };
+        }
+
+        // Tries to find and return the specified assembly by looking in all the known locations where it could be found.
+        private static bool TryResolveAssemblyFromPaths(AssemblyLoadContext context, AssemblyName assemblyName, string searchPath, [NotNullWhen(returnValue: true)] out Assembly? resolvedAssembly)
+        {
+            resolvedAssembly = null;
+            foreach (string cultureSubfolder in GetCultureSubfolders(assemblyName))
+            {
+                foreach (string extension in s_candidateExtensions)
+                {
+                    string candidatePath = Path.Combine(searchPath, cultureSubfolder, $"{assemblyName.Name}.{extension}");
+                    if (s_pathsToAssemblies.ContainsKey(candidatePath) || !File.Exists(candidatePath))
+                    {
+                        continue;
+                    }
+
+                    AssemblyName candidateAssemblyName = AssemblyLoadContext.GetAssemblyName(candidatePath);
+                    if (candidateAssemblyName.Version < assemblyName.Version)
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        resolvedAssembly = context.LoadFromAssemblyPath(candidatePath);
+                        return resolvedAssembly != null;
+                    }
+                    catch
+                    {
+                        if (assemblyName.Name != null)
+                        {
+                            // We were unable to load the assembly from the file path. It is likely that
+                            // a different version of the assembly has already been loaded into the context.
+                            // Be forgiving and attempt to load assembly by name without specifying a version.
+                            resolvedAssembly = context.LoadFromAssemblyName(new AssemblyName(assemblyName.Name));
+                            return resolvedAssembly != null;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static IEnumerable<string> GetCultureSubfolders(AssemblyName assemblyName)
+        {
+            if (!string.IsNullOrEmpty(assemblyName.CultureName))
+            {
+                // Search for satellite assemblies in culture subdirectories of the assembly search
+                // directories, but fall back to the bare search directory if that fails.
+                yield return assemblyName.CultureName;
+            }
+            // If no culture is specified, attempt to load directly from the known dependency paths.
+            yield return string.Empty;
+        }
+    }
+}

--- a/src/PortToTripleSlash/src/libraries/libraries.csproj
+++ b/src/PortToTripleSlash/src/libraries/libraries.csproj
@@ -2,24 +2,23 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="16.9.0" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="16.9.0" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build" Version="17.2.0" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.2.0" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.10.0-1.final" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.3.0-2.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4-beta1.22310.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0-1.final" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0-1.final" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.10.0-1.final" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0-preview.1.21102.12" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0-2.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.0-2.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.3.0-2.final" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0-preview.6.22324.4" />
   </ItemGroup>
 
 </Project>

--- a/src/PortToTripleSlash/tests/PortToTripleSlash/PortToTripleSlashTestData.cs
+++ b/src/PortToTripleSlash/tests/PortToTripleSlash/PortToTripleSlashTestData.cs
@@ -8,6 +8,7 @@ namespace ApiDocsSync.Libraries.Tests
 {
     internal class PortToTripleSlashTestData : TestData
     {
+        private const string BinLogFileName = "output.binlog";
         private const string SourceOriginal = "SourceOriginal.cs";
         private const string SourceExpected = "SourceExpected.cs";
         private const string ProjectDirName = "Project";
@@ -15,6 +16,7 @@ namespace ApiDocsSync.Libraries.Tests
 
         private DirectoryInfo ProjectDir { get; set; }
         internal string ProjectFilePath { get; set; }
+        internal string BinLogPath { get; set; }
 
         internal PortToTripleSlashTestData(
             TestDirectory tempDir,
@@ -51,6 +53,8 @@ namespace ApiDocsSync.Libraries.Tests
             string originCsproj = Path.Combine(testDataPath, $"{assemblyName}.csproj");
             ProjectFilePath = Path.Combine(ProjectDir.FullName, $"{assemblyName}.csproj");
             File.Copy(originCsproj, ProjectFilePath);
+
+            BinLogPath = Path.Combine(ProjectDir.FullName, BinLogFileName);
         }
     }
 }

--- a/src/PortToTripleSlash/tests/PortToTripleSlash/TestData/Basic/MyAssembly.csproj
+++ b/src/PortToTripleSlash/tests/PortToTripleSlash/TestData/Basic/MyAssembly.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Description>This is MyNamespace description.</Description>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/PortToTripleSlash/tests/PortToTripleSlash/TestData/Generics/MyAssembly.csproj
+++ b/src/PortToTripleSlash/tests/PortToTripleSlash/TestData/Generics/MyAssembly.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <Description>This is MyNamespace description.</Description>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/PortToTripleSlash/tests/tests.csproj
+++ b/src/PortToTripleSlash/tests/tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -15,15 +15,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="17.0.0" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="17.0.0" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0-preview-20220131-20" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NuGet.Frameworks" Version="6.1.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0-preview.1.22076.8" />
-    <PackageReference Include="xunit" Version="2.4.2-pre.12" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.Build" Version="17.2.0" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="17.2.0" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0-preview-20220707-01" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0-preview.6.22324.4" />
+    <PackageReference Include="xunit" Version="2.4.2-pre.22" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/PortToTripleSlash/tests/tests.csproj
+++ b/src/PortToTripleSlash/tests/tests.csproj
@@ -6,10 +6,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- All test assets need to get excluded from compilation but still want them to show up in the Solution Explorer. -->
     <Compile Remove="PortToTripleSlash\TestData\Generics\SourceExpected.cs" />
     <Compile Remove="PortToTripleSlash\TestData\Generics\SourceOriginal.cs" />
     <Compile Remove="PortToTripleSlash\TestData\Basic\SourceExpected.cs" />
     <Compile Remove="PortToTripleSlash\TestData\Basic\SourceOriginal.cs" />
+    <Compile Remove="PortToTripleSlash\TestData\Generics\MyAssembly.csproj" />
+    <Compile Remove="PortToTripleSlash\TestData\Basic\MyAssembly.csproj" />
+    <None Include="PortToTripleSlash\TestData\Generics\SourceExpected.cs" />
+    <None Include="PortToTripleSlash\TestData\Generics\SourceOriginal.cs" />
+    <None Include="PortToTripleSlash\TestData\Basic\SourceExpected.cs" />
+    <None Include="PortToTripleSlash\TestData\Basic\SourceOriginal.cs" />
     <None Include="PortToTripleSlash\TestData\Generics\MyAssembly.csproj" />
     <None Include="PortToTripleSlash\TestData\Basic\MyAssembly.csproj" />
   </ItemGroup>
@@ -30,6 +37,7 @@
     <ProjectReference Include="..\src\libraries\libraries.csproj" />
   </ItemGroup>
 
+  <!-- Active issue workaround: https://github.com/dotnet/roslyn/issues/61454 -->
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Copy SourceFiles="$([System.IO.Directory]::GetParent($(BundledRuntimeIdentifierGraphFile)))\NuGet.Frameworks.dll"
           DestinationFolder="$(OutputPath)"

--- a/src/PortToTripleSlash/tests/tests.csproj
+++ b/src/PortToTripleSlash/tests/tests.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Copy SourceFiles="$(MSBuildSDKsPath)\..\NuGet.Frameworks.dll"
+    <Copy SourceFiles="$([System.IO.Directory]::GetParent($(BundledRuntimeIdentifierGraphFile)))\NuGet.Frameworks.dll"
           DestinationFolder="$(OutputPath)"
           ContinueOnError="false" />
   </Target>

--- a/src/PortToTripleSlash/tests/tests.csproj
+++ b/src/PortToTripleSlash/tests/tests.csproj
@@ -30,4 +30,10 @@
     <ProjectReference Include="..\src\libraries\libraries.csproj" />
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Copy SourceFiles="$(MSBuildSDKsPath)\..\NuGet.Frameworks.dll"
+          DestinationFolder="$(OutputPath)"
+          ContinueOnError="false" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
Some fixes to get the tool working back again, @RussKie @jeffhandley.

It works if you execute it manually. It doesn't work when executed from the unit tests due to https://github.com/dotnet/roslyn/issues/61454.

Changes in this PR:
- Updated the projects to net7.0, otherwise we are unable to load the target projects in dotnet/runtime.
- Separated the code that loads the VS instance and the code that loads MSBuild, because as described in the documentation, you must not load Microsoft.Build APIs in the same context where you're loading MSBuildLocator APIs. This includes BinLogger APIs. https://docs.microsoft.com/en-us/visualstudio/msbuild/updating-an-existing-application
- Made the project loading code much faster by loading the workspaces, projects and compilations only once.
- Simplified the code that retrieves INamedTypeSymbol locations for a specified DocsType, and made sure to run this porting code in a single loop. Tests are different, they get executed in two loops because I want to show failures separately.
- Adapted the tests to the new API surface. Will address the failures later when the related roslyn issue gets fixed.
- Various small analyzer fixes (info and warning).

Once this is fixed, we can proceed to improve the code that loads the triple slash comments using the Roslyn APIs (we can try to apply @jeffhandley's refactoring).