### PR TITLE
Port to docs the remarks as xml by default instead of markdown

### DIFF
--- a/src/PortToDocs/src/app/PortToDocs.csproj
+++ b/src/PortToDocs/src/app/PortToDocs.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PortToDocs/src/libraries/Configuration.cs
+++ b/src/PortToDocs/src/libraries/Configuration.cs
@@ -25,6 +25,7 @@ namespace ApiDocsSync.Libraries
             IncludedTypes,
             Initial,
             IntelliSense,
+            MarkdownRemarks,
             PortExceptionsExisting,
             PortExceptionsNew,
             PortMemberParams,
@@ -78,6 +79,7 @@ namespace ApiDocsSync.Libraries
         public HashSet<string> IncludedAssemblies { get; } = new HashSet<string>();
         public HashSet<string> IncludedNamespaces { get; } = new HashSet<string>();
         public HashSet<string> IncludedTypes { get; } = new HashSet<string>();
+        public bool MarkdownRemarks { get; set; } = false;
         public bool PortExceptionsExisting { get; set; } = false;
         public bool PortExceptionsNew { get; set; } = true;
         public bool PortMemberParams { get; set; } = true;
@@ -358,6 +360,10 @@ namespace ApiDocsSync.Libraries
                                     mode = Mode.IntelliSense;
                                     break;
 
+                                case "-MARKDOWNREMARKS":
+                                    mode = Mode.MarkdownRemarks;
+                                    break;
+
                                 case "-PORTEXCEPTIONSEXISTING":
                                     mode = Mode.PortExceptionsExisting;
                                     break;
@@ -450,6 +456,13 @@ namespace ApiDocsSync.Libraries
                                 Log.Info($"  -  {dirPath}");
                             }
 
+                            mode = Mode.Initial;
+                            break;
+                        }
+
+                    case Mode.MarkdownRemarks:
+                        {
+                            config.MarkdownRemarks = ParseOrExit(arg, "Port remarks in markdown");
                             mode = Mode.Initial;
                             break;
                         }

--- a/src/PortToDocs/src/libraries/Docs/DocsAPI.cs
+++ b/src/PortToDocs/src/libraries/Docs/DocsAPI.cs
@@ -257,20 +257,20 @@ namespace ApiDocsSync.Libraries.Docs
             return string.Empty;
         }
 
+        protected void SaveAsIs(string name, string value, bool addIfMissing)
+        {
+            if (TryGetElement(name, addIfMissing, out XElement? element))
+            {
+                XmlHelper.SaveAsIs(element, value);
+                Changed = true;
+            }
+        }
+
         protected void SaveFormattedAsXml(string name, string value, bool addIfMissing)
         {
             if (TryGetElement(name, addIfMissing, out XElement? element))
             {
                 XmlHelper.SaveFormattedAsXml(element, value);
-                Changed = true;
-            }
-        }
-
-        protected void SaveFormattedAsMarkdown(string name, string value, bool addIfMissing, bool isMember)
-        {
-            if (TryGetElement(name, addIfMissing, out XElement? element))
-            {
-                XmlHelper.SaveFormattedAsMarkdown(element, value, isMember);
                 Changed = true;
             }
         }

--- a/src/PortToDocs/src/libraries/Docs/DocsMember.cs
+++ b/src/PortToDocs/src/libraries/Docs/DocsMember.cs
@@ -143,7 +143,7 @@ namespace ApiDocsSync.Libraries.Docs
             }
             set
             {
-                SaveFormattedAsMarkdown("remarks", value, addIfMissing: !value.IsDocsEmpty(), isMember: true);
+                SaveAsIs("remarks", value, addIfMissing: !value.IsDocsEmpty());
             }
         }
 

--- a/src/PortToDocs/src/libraries/Docs/DocsType.cs
+++ b/src/PortToDocs/src/libraries/Docs/DocsType.cs
@@ -255,7 +255,7 @@ namespace ApiDocsSync.Libraries.Docs
             }
             set
             {
-                SaveFormattedAsMarkdown("remarks", value, addIfMissing: !value.IsDocsEmpty(), isMember: false);
+                SaveAsIs("remarks", value, addIfMissing: !value.IsDocsEmpty());
             }
         }
 

--- a/src/PortToDocs/src/libraries/Log.cs
+++ b/src/PortToDocs/src/libraries/Log.cs
@@ -272,6 +272,11 @@ Options:
                                                     Usage example:
                                                         -IncludedTypes FileStream,DirectoryInfo
 
+    -MarkdownRemarks            bool            Default is false (does not port remarks in markdown).
+                                                When set to true, the remarks are ported to Docs using markdown language
+                                                inside a CDATA element.
+                                                When set to false, the remarks are ported in the default ECMAXml format.
+
     -PortExceptionsExisting     bool            Default is false (does not find and append existing exceptions).
                                                 Enable or disable finding, porting and appending summaries from existing exceptions.
                                                 Setting this to true can result in a lot of noise because there is

--- a/src/PortToDocs/src/libraries/ToDocsPorter.cs
+++ b/src/PortToDocs/src/libraries/ToDocsPorter.cs
@@ -494,7 +494,10 @@ namespace ApiDocsSync.Libraries
 
             if (dApiToUpdate.Remarks.IsDocsEmpty() && !remarks.IsDocsEmpty())
             {
-                dApiToUpdate.Remarks = remarks!;
+                dApiToUpdate.Remarks = Config.MarkdownRemarks ?
+                    XmlHelper.GetFormattedAsMarkdown(remarks!, dApiToUpdate is DocsMember) :
+                    XmlHelper.GetFormattedAsXml(remarks!, removeUndesiredEndlines: true);
+
                 PrintModifiedMember("remarks", dApiToUpdate.FilePath, dApiToUpdate.DocId, isEII);
                 TotalModifiedIndividualElements++;
             }

--- a/src/PortToDocs/tests/PortToDocs/PortToDocs.FileSystem.Tests.cs
+++ b/src/PortToDocs/tests/PortToDocs/PortToDocs.FileSystem.Tests.cs
@@ -19,20 +19,20 @@ namespace ApiDocsSync.Libraries.Tests
         // Verifies the basic case of porting all regular fields.
         public void Port_Basic()
         {
-            PortToDocsWithFileSystem("Basic", GetConfiguration());
+            PortToDocsWithFileSystem("Basic", new Configuration() { MarkdownRemarks = true, Save = true });
         }
 
         [Fact]
         public void Port_DontAddMissingRemarks()
         {
-            PortToDocsWithFileSystem("DontAddMissingRemarks", GetConfiguration());
+            PortToDocsWithFileSystem("DontAddMissingRemarks", new Configuration() { MarkdownRemarks = true, Save = true });
         }
 
         [Fact]
         // Verifies porting of APIs living in namespaces whose name match their assembly.
         public void Port_AssemblyAndNamespaceSame()
         {
-            PortToDocsWithFileSystem("AssemblyAndNamespaceSame", GetConfiguration());
+            PortToDocsWithFileSystem("AssemblyAndNamespaceSame", new Configuration() { MarkdownRemarks = true, Save = true });
         }
 
         [Fact]
@@ -40,7 +40,7 @@ namespace ApiDocsSync.Libraries.Tests
         public void Port_AssemblyAndNamespaceDifferent()
         {
             PortToDocsWithFileSystem("AssemblyAndNamespaceDifferent",
-                       GetConfiguration(),
+                       new Configuration() { MarkdownRemarks = true, Save = true },
                        namespaceNames: new[] { TestData.TestNamespace });
         }
 
@@ -50,7 +50,13 @@ namespace ApiDocsSync.Libraries.Tests
         // No interface strings should be ported.
         public void Port_Remarks_NoEII_NoInterfaceRemarks()
         {
-            Configuration c = GetConfiguration(skipInterfaceImplementations: true, skipInterfaceRemarks: true);
+            Configuration c = new Configuration()
+            {
+                MarkdownRemarks = true,
+                SkipInterfaceImplementations = true,
+                SkipInterfaceRemarks = true,
+                Save = true
+            };
             PortToDocsWithFileSystem("Remarks_NoEII_NoInterfaceRemarks", c);
         }
 
@@ -60,7 +66,13 @@ namespace ApiDocsSync.Libraries.Tests
         // Ports EII message and interface method remarks.
         public void Port_Remarks_WithEII_WithInterfaceRemarks()
         {
-            Configuration c = GetConfiguration(skipInterfaceImplementations: false, skipInterfaceRemarks: false);
+            Configuration c = new Configuration()
+            {
+                MarkdownRemarks = true,
+                SkipInterfaceImplementations = false,
+                SkipInterfaceRemarks = false,
+                Save = true
+            };
             PortToDocsWithFileSystem("Remarks_WithEII_WithInterfaceRemarks", c);
         }
 
@@ -70,7 +82,13 @@ namespace ApiDocsSync.Libraries.Tests
         // Ports EII message but no interface method remarks.
         public void Port_Remarks_WithEII_NoInterfaceRemarks()
         {
-            Configuration c = GetConfiguration(skipInterfaceImplementations: false, skipInterfaceRemarks: true);
+            Configuration c = new Configuration()
+            {
+                MarkdownRemarks = true,
+                SkipInterfaceImplementations = false,
+                SkipInterfaceRemarks = true,
+                Save = true
+            };
             PortToDocsWithFileSystem("Remarks_WithEII_NoInterfaceRemarks", c);
         }
 
@@ -78,7 +96,7 @@ namespace ApiDocsSync.Libraries.Tests
         // Verifies that new exceptions are ported.
         public void Port_Exceptions()
         {
-            PortToDocsWithFileSystem("Exceptions", GetConfiguration());
+            PortToDocsWithFileSystem("Exceptions", new Configuration() { MarkdownRemarks = true, Save = true });
         }
 
         [Fact]
@@ -86,7 +104,13 @@ namespace ApiDocsSync.Libraries.Tests
         // language review, does not get ported if its above the difference threshold.
         public void Port_Exception_ExistingCref()
         {
-            Configuration c = GetConfiguration(portExceptionsExisting: true, exceptionCollisionThreshold: 60);
+            Configuration c = new Configuration()
+            {
+                MarkdownRemarks = true,
+                PortExceptionsExisting = true,
+                ExceptionCollisionThreshold = 60,
+                Save = true
+            };
             PortToDocsWithFileSystem("Exception_ExistingCref", c);
         }
 
@@ -94,7 +118,7 @@ namespace ApiDocsSync.Libraries.Tests
         // Avoid porting enum field remarks
         public void Port_EnumRemarks()
         {
-            PortToDocsWithFileSystem("EnumRemarks", GetConfiguration());
+            PortToDocsWithFileSystem("EnumRemarks", new Configuration() { MarkdownRemarks = true, Save = true });
         }
 
         [Fact]
@@ -103,7 +127,7 @@ namespace ApiDocsSync.Libraries.Tests
         public void Port_InheritDoc()
         {
             PortToDocsWithFileSystem("InheritDoc",
-                       GetConfiguration(),
+                       new Configuration() { MarkdownRemarks = true, Save = true },
                        assemblyNames: new[] { TestData.TestAssembly, "System" });
         }
 
@@ -135,28 +159,6 @@ namespace ApiDocsSync.Libraries.Tests
                 DirectoryRecursiveCopy(subdir.FullName, tempPath);
             }
         }
-
-        private static Configuration GetConfiguration(
-            bool disablePrompts = true,
-            bool printUndoc = false,
-            bool save = true,
-            bool skipInterfaceImplementations = true,
-            bool skipInterfaceRemarks = true,
-            bool portTypeRemarks = true,
-            bool portMemberRemarks = true,
-            bool portExceptionsExisting = false,
-            int exceptionCollisionThreshold = 70) => new()
-            {
-                DisablePrompts = disablePrompts,
-                ExceptionCollisionThreshold = exceptionCollisionThreshold,
-                PortExceptionsExisting = portExceptionsExisting,
-                PortMemberRemarks = portMemberRemarks,
-                PortTypeRemarks = portTypeRemarks,
-                PrintUndoc = printUndoc,
-                Save = save,
-                SkipInterfaceImplementations = skipInterfaceImplementations,
-                SkipInterfaceRemarks = skipInterfaceRemarks
-            };
 
         private static void PortToDocsWithFileSystem(
                 string testName,

--- a/src/PortToDocs/tests/PortToDocs/PortToDocs.Strings.Tests.cs
+++ b/src/PortToDocs/tests/PortToDocs/PortToDocs.Strings.Tests.cs
@@ -187,7 +187,11 @@ See <xref:MyNamespace.MyType.MyMethod>.
   </Members>
 </Type>";
 
-            TestWithStrings(originalIntellisense, originalDocs, expectedDocs);
+            Configuration configuration = new Configuration()
+            {
+                MarkdownRemarks = true
+            };
+            TestWithStrings(originalIntellisense, originalDocs, expectedDocs, configuration);
         }
 
         [Fact]
@@ -273,8 +277,11 @@ Remarks: `bool`, `byte`, `sbyte`, `char`, `decimal`, `double`, `float`, `int`, `
     </Member>
   </Members>
 </Type>";
-
-            TestWithStrings(originalIntellisense, originalDocs, expectedDocs);
+            Configuration configuration = new Configuration()
+            {
+                MarkdownRemarks = true
+            };
+            TestWithStrings(originalIntellisense, originalDocs, expectedDocs, configuration);
         }
 
         [Fact]
@@ -393,7 +400,11 @@ A link to itself: <xref:MyNamespace.MyType.%23ctor(System.Object)>.
   </Members>
 </Type>";
 
-            TestWithStrings(originalIntellisense, originalDocs, expectedDocs);
+            Configuration configuration = new Configuration()
+            {
+                MarkdownRemarks = true
+            };
+            TestWithStrings(originalIntellisense, originalDocs, expectedDocs, configuration);
         }
 
         [Fact]
@@ -488,7 +499,11 @@ I have a reference to the generic type <xref:MyNamespace.MyGenericType%601> and 
   </Members>
 </Type>";
 
-            TestWithStrings(originalIntellisense, originalDocs, expectedDocs);
+            Configuration configuration = new Configuration()
+            {
+                MarkdownRemarks = true
+            };
+            TestWithStrings(originalIntellisense, originalDocs, expectedDocs, configuration);
         }
 
         [Fact]
@@ -574,7 +589,11 @@ See <xref:MyNamespace.MyType.MyMethod>.
   </Members>
 </Type>";
 
-            TestWithStrings(originalIntellisense, originalDocs, expectedDocs);
+            Configuration configuration = new Configuration()
+            {
+                MarkdownRemarks = true
+            };
+            TestWithStrings(originalIntellisense, originalDocs, expectedDocs, configuration);
         }
 
         [Fact]
@@ -660,7 +679,11 @@ Langword `true`.
   </Members>
 </Type>";
 
-            TestWithStrings(originalIntellisense, originalDocs, expectedDocs);
+            Configuration configuration = new Configuration()
+            {
+                MarkdownRemarks = true
+            };
+            TestWithStrings(originalIntellisense, originalDocs, expectedDocs, configuration);
         }
 
         [Fact]
@@ -755,7 +778,11 @@ Paramref `myParam`.
   </Members>
 </Type>";
 
-            TestWithStrings(originalIntellisense, originalDocs, expectedDocs);
+            Configuration configuration = new Configuration()
+            {
+                MarkdownRemarks = true
+            };
+            TestWithStrings(originalIntellisense, originalDocs, expectedDocs, configuration);
         }
 
         [Fact]
@@ -875,12 +902,16 @@ Typeparamref `T`.
   </Members>
 </Type>";
 
-            TestWithStrings(originalIntellisense, originalDocs, expectedDocs);
+            Configuration configuration = new Configuration()
+            {
+                MarkdownRemarks = true
+            };
+            TestWithStrings(originalIntellisense, originalDocs, expectedDocs, configuration);
         }
 
-        private static void TestWithStrings(string originalIntellisense, string originalDocs, string expectedDocs)
+        private static void TestWithStrings(string originalIntellisense, string originalDocs, string expectedDocs, Configuration configuration = null)
         {
-            Configuration configuration = new Configuration();
+            configuration ??= new Configuration();
             configuration.IncludedAssemblies.Add(TestData.TestAssembly);
             var porter = new ToDocsPorter(configuration);
 

--- a/src/PortToDocs/tests/PortToDocs/PortToDocs.Strings.Tests.cs
+++ b/src/PortToDocs/tests/PortToDocs/PortToDocs.Strings.Tests.cs
@@ -909,6 +909,83 @@ Typeparamref `T`.
             TestWithStrings(originalIntellisense, originalDocs, expectedDocs, configuration);
         }
 
+        [Fact]
+        public void XmlRemarks()
+        {
+            // The default formatting for remarks is xml
+
+            string originalIntellisense = @"<?xml version=""1.0""?>
+<doc>
+  <assembly>
+    <name>MyAssembly</name>
+  </assembly>
+  <members>
+    <member name=""T:MyNamespace.MyType"">
+      <remarks>Remarks for type <see cref=""T:MyNamespace.MyType""/>.</remarks>
+    </member>
+    <member name=""M:MyNamespace.MyType.MyMethod"">
+      <remarks>Remarks for <see cref=""M:MyNamespace.MyType.MyMethod""/>.</remarks>
+    </member>
+  </members>
+</doc>";
+
+            string originalDocs = @"<Type Name=""MyType"" FullName=""MyNamespace.MyType"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=""MyMethod"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyMethod"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+            string expectedDocs = @"<Type Name=""MyType"" FullName=""MyNamespace.MyType"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>Remarks for type <see cref=""T:MyNamespace.MyType"" />.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=""MyMethod"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyMethod"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>Remarks for <see cref=""M:MyNamespace.MyType.MyMethod"" />.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+            TestWithStrings(originalIntellisense, originalDocs, expectedDocs, new Configuration());
+        }
+
         private static void TestWithStrings(string originalIntellisense, string originalDocs, string expectedDocs, Configuration configuration = null)
         {
             configuration ??= new Configuration();


### PR DESCRIPTION
@gewarren I finally got time to address this.