### PR TITLE
Fix detection of nested types

### DIFF
--- a/src/PortToTripleSlash/src/libraries/AllTypesVisitor.cs
+++ b/src/PortToTripleSlash/src/libraries/AllTypesVisitor.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+
+namespace ApiDocsSync.Libraries
+{
+
+    internal class AllTypesVisitor : SymbolVisitor
+    {
+        public readonly List<ISymbol> AllTypesSymbols = new();
+        public override void VisitNamedType(INamedTypeSymbol symbol)
+        {
+            AllTypesSymbols.Add(symbol);
+            foreach (INamedTypeSymbol typeMember in symbol.GetTypeMembers())
+            {
+                Visit(typeMember);
+            }
+        }
+        public override void VisitNamespace(INamespaceSymbol symbol) => Parallel.ForEach(symbol.GetMembers(), s => s.Accept(this));
+        public override void VisitDynamicType(IDynamicTypeSymbol symbol) => AllTypesSymbols.Add(symbol);
+        public override void VisitFunctionPointerType(IFunctionPointerTypeSymbol symbol) => AllTypesSymbols.Add(symbol);
+        public override void VisitAlias(IAliasSymbol symbol) => AllTypesSymbols.Add(symbol);
+    }
+}

--- a/src/PortToTripleSlash/src/libraries/Docs/DocsAPI.cs
+++ b/src/PortToTripleSlash/src/libraries/Docs/DocsAPI.cs
@@ -11,6 +11,8 @@ namespace ApiDocsSync.Libraries.Docs
 {
     internal abstract class DocsAPI : IDocsAPI
     {
+        private string? _docId;
+        private string? _docIdUnprefixed;
         private List<DocsParam>? _params;
         private List<DocsParameter>? _parameters;
         private List<DocsTypeParameter>? _typeParameters;
@@ -32,7 +34,10 @@ namespace ApiDocsSync.Libraries.Docs
 
         public abstract bool Changed { get; set; }
         public string FilePath { get; set; } = string.Empty;
-        public abstract string DocId { get; }
+
+        public string DocId => _docId ??= GetApiSignatureDocId();
+
+        public string DocIdUnprefixed => _docIdUnprefixed ??= DocId[2..];
 
         /// <summary>
         /// The Parameter elements found inside the Parameters section.
@@ -238,6 +243,10 @@ namespace ApiDocsSync.Libraries.Docs
             Changed = true;
             return new DocsTypeParam(this, typeParam);
         }
+
+        // For Types, these elements are called TypeSignature.
+        // For Members, these elements are called MemberSignature.
+        protected abstract string GetApiSignatureDocId();
 
         protected string GetNodesInPlainText(string name)
         {

--- a/src/PortToTripleSlash/src/libraries/Docs/DocsMember.cs
+++ b/src/PortToTripleSlash/src/libraries/Docs/DocsMember.cs
@@ -12,7 +12,6 @@ namespace ApiDocsSync.Libraries.Docs
     {
         private string? _memberName;
         private List<DocsMemberSignature>? _memberSignatures;
-        private string? _docId;
         private List<DocsException>? _exceptions;
 
         public DocsMember(string filePath, DocsType parentType, XElement xeMember)
@@ -52,25 +51,6 @@ namespace ApiDocsSync.Libraries.Docs
                     _memberSignatures = XERoot.Elements("MemberSignature").Select(x => new DocsMemberSignature(x)).ToList();
                 }
                 return _memberSignatures;
-            }
-        }
-
-        public override string DocId
-        {
-            get
-            {
-                if (_docId == null)
-                {
-                    _docId = string.Empty;
-                    DocsMemberSignature? ms = MemberSignatures.FirstOrDefault(x => x.Language == "DocId");
-                    if (ms == null)
-                    {
-                        string message = string.Format("Could not find a DocId MemberSignature for '{0}'", MemberName);
-                        throw new Exception(message);
-                    }
-                    _docId = ms.Value.DocIdEscaped();
-                }
-                return _docId;
             }
         }
 
@@ -198,6 +178,16 @@ namespace ApiDocsSync.Libraries.Docs
             Docs.Add(exception);
             Changed = true;
             return new DocsException(this, exception);
+        }
+
+        protected override string GetApiSignatureDocId()
+        {
+            DocsMemberSignature? dts = MemberSignatures.FirstOrDefault(x => x.Language == "DocId");
+            if (dts == null)
+            {
+                throw new FormatException($"DocId TypeSignature not found for {MemberName}");
+            }
+            return dts.Value;
         }
     }
 }

--- a/src/PortToTripleSlash/src/libraries/Docs/DocsType.cs
+++ b/src/PortToTripleSlash/src/libraries/Docs/DocsType.cs
@@ -19,7 +19,6 @@ namespace ApiDocsSync.Libraries.Docs
         private string? _name;
         private string? _fullName;
         private string? _namespace;
-        private string? _docId;
         private string? _baseTypeName;
         private List<string>? _interfaceNames;
         private List<DocsAttribute>? _attributes;
@@ -111,24 +110,6 @@ namespace ApiDocsSync.Libraries.Docs
                     _typesSignatures = XERoot.Elements("TypeSignature").Select(x => new DocsTypeSignature(x)).ToList();
                 }
                 return _typesSignatures;
-            }
-        }
-
-        public override string DocId
-        {
-            get
-            {
-                if (_docId == null)
-                {
-                    DocsTypeSignature? dts = TypeSignatures.FirstOrDefault(x => x.Language == "DocId");
-                    if (dts == null)
-                    {
-                        string message = $"DocId TypeSignature not found for FullName";
-                        throw new Exception($"DocId TypeSignature not found for FullName");
-                    }
-                    _docId = dts.Value.DocIdEscaped();
-                }
-                return _docId;
             }
         }
 
@@ -265,6 +246,16 @@ namespace ApiDocsSync.Libraries.Docs
         public override string ToString()
         {
             return FullName;
+        }
+
+        protected override string GetApiSignatureDocId()
+        {
+            DocsTypeSignature? dts = TypeSignatures.FirstOrDefault(x => x.Language == "DocId");
+            if (dts == null)
+            {
+                throw new FormatException($"DocId TypeSignature not found for {FullName}");
+            }
+            return dts.Value;
         }
     }
 }

--- a/src/PortToTripleSlash/src/libraries/Docs/IDocsAPI.cs
+++ b/src/PortToTripleSlash/src/libraries/Docs/IDocsAPI.cs
@@ -13,6 +13,7 @@ namespace ApiDocsSync.Libraries.Docs
         public abstract bool Changed { get; set; }
         public abstract string FilePath { get; set; }
         public abstract string DocId { get; }
+        public abstract string DocIdUnprefixed { get; }
         public abstract XElement Docs { get; }
         public abstract List<DocsParameter> Parameters { get; }
         public abstract List<DocsParam> Params { get; }

--- a/src/PortToTripleSlash/src/libraries/MSBuildLoader.cs
+++ b/src/PortToTripleSlash/src/libraries/MSBuildLoader.cs
@@ -121,7 +121,7 @@ namespace ApiDocsSync.Libraries
             return null;
         }
 
-        private async Task<ResolvedProject?> TryGetResolvedProjectAsync(ResolvedWorkspace resolvedWorkspace, string projectPath,  CancellationToken cancellationToken)
+        private async Task<ResolvedProject?> TryGetResolvedProjectAsync(ResolvedWorkspace resolvedWorkspace, string projectPath, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -135,11 +135,10 @@ namespace ApiDocsSync.Libraries
                 {
                     Log.Info($"Found the project in this workspace. Attempting to get compilation...");
                     Compilation? compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-
                     if (compilation != null)
                     {
                         Log.Info($"Found the compilation for this project. Creating the resolved project...");
-                        resolvedProject = new ResolvedProject(resolvedWorkspace, project, compilation);
+                        resolvedProject = new ResolvedProject(resolvedWorkspace, projectPath, project, compilation);
                         resolvedWorkspace.ResolvedProjects.Add(resolvedProject);
                     }
                     else
@@ -176,47 +175,6 @@ namespace ApiDocsSync.Libraries
                     throw new Exception(message);
                 }
             }
-        }
-    }
-
-    public class ResolvedWorkspace
-    {
-        public MSBuildWorkspace Workspace { get; private set; }
-        public List<ResolvedProject> ResolvedProjects { get; }
-        public ResolvedWorkspace(MSBuildWorkspace workspace)
-        {
-            Workspace = workspace;
-            ResolvedProjects = new List<ResolvedProject>();
-        }
-    }
-
-    public class ResolvedProject
-    {
-        public ResolvedWorkspace ResolvedWorkspace { get; private set; }
-        public Project Project { get; private set; }
-        public Compilation Compilation { get; private set; }
-        public ResolvedProject(ResolvedWorkspace resolvedWorkspace, Project project, Compilation compilation)
-        {
-            ResolvedWorkspace = resolvedWorkspace;
-            Project = project;
-            Compilation = compilation;
-        }
-    }
-
-    public class ResolvedLocation
-    {
-        public string TypeName { get; private set; }
-        public ResolvedProject ResolvedProject { get; private set; }
-        public Location Location { get; private set; }
-        public SyntaxTree Tree { get; set; }
-        public SemanticModel Model { get; set; }
-        public ResolvedLocation(string typeName, ResolvedProject resolvedProject, Location location, SyntaxTree tree)
-        {
-            TypeName = typeName;
-            ResolvedProject = resolvedProject;
-            Location = location;
-            Tree = tree;
-            Model = resolvedProject.Compilation.GetSemanticModel(Tree);
         }
     }
 }

--- a/src/PortToTripleSlash/src/libraries/ResolvedLocation.cs
+++ b/src/PortToTripleSlash/src/libraries/ResolvedLocation.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+
+namespace ApiDocsSync.Libraries
+{
+    public class ResolvedLocation
+    {
+        public string TypeName { get; private set; }
+        public ResolvedProject ResolvedProject { get; private set; }
+        public Location Location { get; private set; }
+        public SyntaxTree Tree { get; set; }
+        public SemanticModel Model { get; set; }
+        public ResolvedLocation(string typeName, ResolvedProject resolvedProject, Location location, SyntaxTree tree)
+        {
+            TypeName = typeName;
+            ResolvedProject = resolvedProject;
+            Location = location;
+            Tree = tree;
+            Model = resolvedProject.Compilation.GetSemanticModel(Tree);
+        }
+    }
+}

--- a/src/PortToTripleSlash/src/libraries/ResolvedProject.cs
+++ b/src/PortToTripleSlash/src/libraries/ResolvedProject.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+
+namespace ApiDocsSync.Libraries
+{
+    public class ResolvedProject
+    {
+        public ResolvedWorkspace ResolvedWorkspace { get; private set; }
+        public Project Project { get; private set; }
+        public Compilation Compilation { get; private set; }
+        public string ProjectPath { get; private set; }
+        public ResolvedProject(ResolvedWorkspace resolvedWorkspace, string projectPath, Project project, Compilation compilation)
+        {
+            ResolvedWorkspace = resolvedWorkspace;
+            Project = project;
+            Compilation = compilation;
+            ProjectPath = projectPath;
+        }
+    }
+}

--- a/src/PortToTripleSlash/src/libraries/ResolvedWorkspace.cs
+++ b/src/PortToTripleSlash/src/libraries/ResolvedWorkspace.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.MSBuild;
+
+namespace ApiDocsSync.Libraries
+{
+    public class ResolvedWorkspace
+    {
+        public MSBuildWorkspace Workspace { get; private set; }
+        public List<ResolvedProject> ResolvedProjects { get; }
+        public ResolvedWorkspace(MSBuildWorkspace workspace)
+        {
+            Workspace = workspace;
+            ResolvedProjects = new List<ResolvedProject>();
+        }
+    }
+}

--- a/src/PortToTripleSlash/src/libraries/ToTripleSlashPorter.cs
+++ b/src/PortToTripleSlash/src/libraries/ToTripleSlashPorter.cs
@@ -3,13 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Reflection.Metadata.Ecma335;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,7 +17,7 @@ using Microsoft.CodeAnalysis;
 
 namespace ApiDocsSync.Libraries
 {
-    public class ToTripleSlashPorter
+    public partial class ToTripleSlashPorter
     {
         private readonly string _pathSrcCoreclr = Path.Combine("src", "coreclr");
         private readonly string _systemPrivateCoreLib = "SYSTEM.PRIVATE.CORELIB";
@@ -42,286 +40,206 @@ namespace ApiDocsSync.Libraries
         /// </summary>
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            CollectFiles();
+            cancellationToken.ThrowIfCancellationRequested();
 
-            if (!_docsComments.Types.Any())
+            if (!TryCollectFiles())
             {
-                Log.Error("No Docs Type APIs found. Is the Docs xml path correct? Exiting.");
-                Environment.Exit(0);
+                Log.Error("No docs files found.");
+                return;
             }
-
-            foreach (DocsType docsType in _docsComments.Types.Values)
-            {
-                Log.Info($"Looking for symbol locations for {docsType.TypeName}...");
-                docsType.SymbolLocations = await CollectSymbolLocationsAsync(docsType.TypeName, cancellationToken).ConfigureAwait(false);
-                Log.Info($"Finished looking for symbol locations for {docsType.TypeName}. Now attempting to port...");
-                await PortAsync(docsType, throwOnSymbolsNotFound: false, cancellationToken).ConfigureAwait(false);
-            }
+            await MatchSymbolsAsync(cancellationToken).ConfigureAwait(false);
+            await PortAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
         ///  Collects the docs xml files.
         /// </summary>
-        public void CollectFiles()
+        public bool TryCollectFiles()
         {
             _docsComments.CollectFiles();
-            if (!_docsComments.Types.Any())
-            {
-                throw new Exception("No docs type APIs found.");
-            }
+            return _docsComments.Types.Any();
         }
 
         /// <summary>
         /// Iterates through all the xml files and collects symbols from the found projects for each one.
         /// </summary>
-        public async Task MatchSymbolsAsync(bool throwOnSymbolsNotFound, CancellationToken cancellationToken)
+        public async Task MatchSymbolsAsync(CancellationToken cancellationToken)
         {
             Debug.Assert(_docsComments.Types.Any());
+            cancellationToken.ThrowIfCancellationRequested();
+
             Log.Info("Looking for symbol locations for all Docs types...");
             foreach (DocsType docsType in _docsComments.Types.Values)
             {
-                docsType.SymbolLocations = await CollectSymbolLocationsAsync(docsType.TypeName, cancellationToken).ConfigureAwait(false);
-                if (throwOnSymbolsNotFound)
-                {
-                    VerifySymbolLocations(docsType);
-                }
+                await CollectSymbolLocationsAsync(docsType, cancellationToken).ConfigureAwait(false);
             }
         }
 
         /// <summary>
         /// Iterates through all the found xml files and ports their documentation to the locations of all its found symbols.
         /// </summary>
-        public async Task PortAsync(bool throwOnSymbolsNotFound, CancellationToken cancellationToken)
+        public async Task PortAsync(CancellationToken cancellationToken)
         {
             Debug.Assert(_docsComments.Types.Any());
+            cancellationToken.ThrowIfCancellationRequested();
+
             Log.Info($"Now attempting to port all found symbols...");
             foreach (DocsType docsType in _docsComments.Types.Values)
             {
-                await PortAsync(docsType, throwOnSymbolsNotFound, cancellationToken).ConfigureAwait(false);
-            }
-        }
-
-        /// <summary>
-        /// Ports the documentation of the specified xml file to the locations of all its found symbols.
-        /// </summary>
-        internal async Task PortAsync(DocsType docsType, bool throwOnSymbolsNotFound, CancellationToken cancellationToken)
-        {
-            if (throwOnSymbolsNotFound)
-            {
-                VerifySymbolLocations(docsType);
-            }
-            else if (docsType.SymbolLocations == null || !docsType.SymbolLocations.Any())
-            {
-                Log.Warning($"No symbols found for '{docsType.TypeName}'. Skipping.");
-                return;
-            }
-
-            Log.Cyan($"Porting comments for '{docsType.TypeName}'. Locations: {docsType.SymbolLocations!.Count}...");
-            foreach (ResolvedLocation resolvedLocation in docsType.SymbolLocations)
-            {
-                Log.Info($"Porting docs for tree '{resolvedLocation.Tree.FilePath}'...");
-                TripleSlashSyntaxRewriter rewriter = new(_docsComments, resolvedLocation.Model);
-                SyntaxNode? newRoot = rewriter.Visit(resolvedLocation.Tree.GetRoot(cancellationToken));
-                if (newRoot == null)
+                if (docsType.SymbolLocations == null || !docsType.SymbolLocations.Any())
                 {
-                    throw new Exception($"Returned null root node for {docsType.TypeName} in {resolvedLocation.Tree.FilePath}");
+                    Log.Warning($"No symbols found for '{docsType.DocId}'. Skipping.");
+                    continue;
                 }
 
-                await File.WriteAllTextAsync(resolvedLocation.Tree.FilePath, newRoot.ToFullString(), cancellationToken).ConfigureAwait(false);
-                Log.Success($"Docs ported to '{docsType.TypeName}'.");
+                Log.Cyan($"Porting comments for '{docsType.TypeName}'. Locations: {docsType.SymbolLocations!.Count}...");
+                foreach (ResolvedLocation resolvedLocation in docsType.SymbolLocations)
+                {
+                    Log.Info($"Porting docs for tree '{resolvedLocation.Tree.FilePath}'...");
+                    TripleSlashSyntaxRewriter rewriter = new(_docsComments, resolvedLocation.Model);
+                    SyntaxNode? newRoot = rewriter.Visit(resolvedLocation.Tree.GetRoot(cancellationToken));
+                    if (newRoot == null)
+                    {
+                        throw new Exception($"Returned null root node for {docsType.TypeName} in {resolvedLocation.Tree.FilePath}");
+                    }
+
+                    await File.WriteAllTextAsync(resolvedLocation.Tree.FilePath, newRoot.ToFullString(), cancellationToken).ConfigureAwait(false);
+                    Log.Success($"Docs ported to '{docsType.TypeName}'.");
+                }
             }
         }
 
-        private static void VerifySymbolLocations(DocsType docsType)
-        {
-            if (docsType.SymbolLocations == null)
-            {
-                throw new Exception($"Symbol locations null for '{docsType.TypeName}'.");
-            }
-            else if (!docsType.SymbolLocations.Any())
-            {
-                throw new Exception($"No symbols found for '{docsType.TypeName}'");
-            }
-        }
-
-        private async Task<List<ResolvedLocation>?> CollectSymbolLocationsAsync(string docsTypeName, CancellationToken cancellationToken)
+        private async Task CollectSymbolLocationsAsync(DocsType docsType, CancellationToken cancellationToken)
         {
             Debug.Assert(_config.Loader != null);
-            ResolvedProject? mainProject = _config.Loader.MainProject;
-            Debug.Assert(mainProject != null);
+            Debug.Assert(_config.Loader.MainProject != null);
+            cancellationToken.ThrowIfCancellationRequested();
 
-            // If the symbol is not found in the current compilation, nothing to do - It means the Docs
-            // for APIs from an unrelated namespace were loaded for this compilation's assembly
-            if (!TryGetNamedSymbol(mainProject.Compilation, docsTypeName, out INamedTypeSymbol? symbol))
+            docsType.SymbolLocations = new List<ResolvedLocation>();
+
+            FindLocationsOfSymbolInResolvedProject(docsType, _config.Loader.MainProject);
+
+            foreach (ProjectReference projectReference in _config.Loader.MainProject.Project.ProjectReferences)
             {
-                Log.Info($"Type symbol '{docsTypeName}' not found in compilation for '{_config.CsProj}'.");
-                return null;
+                if (TryGetProjectPath(projectReference, out string? referencedProjectPath, out string? referencedProjectNamespace))
+                {
+                    await FindLocationsOfSymbolInProjectPathAsync(docsType, referencedProjectPath, cancellationToken).ConfigureAwait(false);
+
+                    // If the symbol was found in corelib, try to also find it in mono
+                    if (referencedProjectNamespace == _systemPrivateCoreLib && referencedProjectPath.Contains(_pathSrcCoreclr))
+                    {
+                        string monoProjectPath = MonoProjectPathReplacementRegex().Replace(referencedProjectPath, "src${separator}mono");
+                        await FindLocationsOfSymbolInProjectPathAsync(docsType, monoProjectPath, cancellationToken).ConfigureAwait(false);
+                    }
+                }
             }
 
-            // Make sure at least one syntax tree of this symbol can be found in the current project's compilation
-            if (!symbol.Locations.Any())
+            if (!docsType.SymbolLocations.Any())
             {
-                throw new Exception($"The symbol for the type '{docsTypeName}' had no locations in '{_config.CsProj}'.");
+                Log.Error($"No symbols found for docs type '{docsType.DocId}'.");
             }
-
-            Log.Cyan($"Type symbol '{docsTypeName}' found in compilation for '{_config.CsProj}'.");
-
-            // Otherwise, port the exact same comments in each location
-            List<ResolvedLocation> resolvedLocations = new();
-            GetMatchingLocationsForSymbolInProject(resolvedLocations, mainProject, symbol.Locations, docsTypeName);
-
-            Log.Info($"Also trying to find '{symbol.Name}' in the referenced projects of project '{_config.CsProj}'...");
-            await FindSymbolInReferencedProjectsAsync(resolvedLocations, docsTypeName, mainProject.Project.ProjectReferences, cancellationToken).ConfigureAwait(false);
-
-            return resolvedLocations;
         }
 
-        private static void GetMatchingLocationsForSymbolInProject(List<ResolvedLocation> resolvedLocations, ResolvedProject resolvedProject, ImmutableArray<Location> symbolLocations, string docsTypeName)
+        private bool TryGetProjectPath(ProjectReference projectReference, [NotNullWhen(returnValue: true)] out string? projectPath, [NotNullWhen(returnValue: true)] out string? projectNamespace)
         {
-            int n = 0;
-            foreach (Location location in symbolLocations)
+            projectNamespace = null;
+
+            projectPath = typeof(ProjectId).GetProperty("DebugName", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(projectReference.ProjectId)?.ToString();
+
+            if (projectPath != null)
             {
-                if (location.SourceTree == null)
+                string ns = Path.GetFileNameWithoutExtension(projectPath).ToUpperInvariant();
+                projectNamespace = ns;
+
+                // Skip looking in projects whose namespace that were explicitly excluded or not explicitly included
+                // The only exception is System.Private.CoreLib, which we should always explore
+                if (projectNamespace != _systemPrivateCoreLib)
                 {
-                    Log.Error($"Location tree was null for {docsTypeName}. Skipping...");
-                }
-                else if (IsLocationTreeInCompilationTrees(location.SourceTree, resolvedProject.Compilation))
-                {
-                    Log.Info($"Symbol '{docsTypeName}' located in '{location.SourceTree.FilePath}'.");
-                    if (resolvedLocations.Any(rl => rl.Tree.FilePath == location.SourceTree.FilePath))
+                    if (!_config.IncludedNamespaces.Any(x => x.ToUpperInvariant().StartsWith(ns)) ||
+                         _config.ExcludedNamespaces.Any(x => x.ToUpperInvariant().StartsWith(ns)))
                     {
-                        Log.Info($"Tree '{location.SourceTree.FilePath}' was already added for symbol '{docsTypeName}'. Skipping.");
+                        Log.Warning($"Skipping project '{projectPath}' because namespace '{projectNamespace}' was not added to -IncludedNamespaces or was added to -ExcludedNamespaces.");
+                        projectPath = null;
+                        projectNamespace = null;
+                    }
+                }
+            }
+
+            return projectPath != null;
+        }
+
+        private async Task FindLocationsOfSymbolInProjectPathAsync(DocsType docsType, string projectPath, CancellationToken cancellationToken)
+        {
+            Debug.Assert(_config.Loader != null);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            ResolvedProject project = await _config.Loader.LoadProjectAsync(projectPath, isMono: false, cancellationToken).ConfigureAwait(false);
+
+            FindLocationsOfSymbolInResolvedProject(docsType, project);
+        }
+
+        private static void FindLocationsOfSymbolInResolvedProject(DocsType docsType, ResolvedProject project)
+        {
+            // First, collect all types in the current compilation
+            AllTypesVisitor visitor = new();
+            visitor.Visit(project.Compilation.GlobalNamespace);
+
+            // Next, filter types that match the current docsType
+            IEnumerable<ISymbol> currentTypeSymbols = visitor.AllTypesSymbols.Where(x => x != null && x.GetDocumentationCommentId() == docsType.DocId);
+            if (!currentTypeSymbols.Any())
+            {
+                throw new Exception($"The symbol for the type '{docsType.DocId}' had no locations in '{project.ProjectPath}'.");
+            }
+
+            foreach (ISymbol symbol in currentTypeSymbols)
+            {
+                docsType.SymbolLocations = GetSymbolLocations(project, symbol);
+            }
+        }
+
+        private static List<ResolvedLocation> GetSymbolLocations(ResolvedProject resolvedProject, ISymbol symbol)
+        {
+            List<ResolvedLocation> resolvedLocations = new();
+
+            int n = 0;
+            string docId = symbol.GetDocumentationCommentId() ?? throw new NullReferenceException($"DocID was null for symbol '{symbol}'");
+            foreach (Location location in symbol.Locations)
+            {
+                SyntaxTree? tree = location.SourceTree;
+                if (tree == null)
+                {
+                    Log.Error($"Location tree was null for {docId}. Skipping...");
+                }
+                // Verify that this location tree is among the compilation trees
+                else if (resolvedProject.Compilation.SyntaxTrees.FirstOrDefault(x => x.FilePath == tree.FilePath) is not null)
+                {
+                    Log.Info($"Symbol '{docId}' located in '{tree.FilePath}'.");
+                    if (resolvedLocations.Any(rl => rl.Tree.FilePath == tree.FilePath))
+                    {
+                        Log.Info($"Tree '{tree.FilePath}' was already added for symbol '{docId}'. Skipping.");
                     }
                     else
                     {
-                        ResolvedLocation resolvedLocation = new(docsTypeName, resolvedProject, location, location.SourceTree);
-                        Log.Success($"Adding tree '{resolvedLocation.Tree.FilePath}' for '{docsTypeName}'...");
+                        ResolvedLocation resolvedLocation = new(docId, resolvedProject, location, tree);
+                        Log.Success($"Adding tree '{resolvedLocation.Tree.FilePath}' for '{docId}'...");
                         resolvedLocations.Add(resolvedLocation);
                     }
                 }
                 else
                 {
-                    Log.Info(false, $"Symbol '{docsTypeName}' not found in compilation trees of '{location.SourceTree.FilePath}'.");
-                    if (n < symbolLocations.Length)
+                    Log.Info(false, $"Symbol '{docId}' not found in compilation trees of '{tree.FilePath}'.");
+                    if (n < symbol.Locations.Length)
                     {
                         Log.Info(true, " Trying the next location...");
                     }
                 }
                 n++;
             }
+
+            return resolvedLocations;
         }
 
-        // Tries to find the specified type among the source code files of all the specified projects.
-        // If not found, logs a warning message.
-        private async Task FindSymbolInReferencedProjectsAsync(List<ResolvedLocation> resolvedLocations, string docsTypeName, IEnumerable<ProjectReference> projectReferences, CancellationToken cancellationToken)
-        {
-            int n = 0;
-            foreach (ProjectReference projectReference in projectReferences)
-            {
-                string projectPath = GetProjectPath(projectReference);
-                string projectNamespace = Path.GetFileNameWithoutExtension(projectPath);
-                string projectNamespaceToUpper = projectNamespace.ToUpperInvariant();
-
-                // Skip looking in projects whose namespace that were explicitly excluded or not explicitly included
-                // The only exception is System.Private.CoreLib, which we should always explore
-                if (projectNamespaceToUpper != _systemPrivateCoreLib)
-                {
-                    if (_config.ExcludedNamespaces.Any(x => x.StartsWith(projectNamespace)))
-                    {
-                        Log.Info($"Skipping project '{projectPath}' which was added to -ExcludedNamespaces.");
-                        continue;
-                    }
-                    else if (!_config.IncludedNamespaces.Any(x => x.StartsWith(projectNamespace)))
-                    {
-                        Log.Info($"Skipping project '{projectPath}' which was not added to -IncludedNamespaces.");
-                        continue;
-                    }
-                }
-
-                (ResolvedProject? resolvedProject, INamedTypeSymbol? symbol) = await TryFindSymbolInReferencedProjectAsync(projectPath, docsTypeName, isMono: false, cancellationToken).ConfigureAwait(false);
-                if (resolvedProject != null && symbol != null)
-                {
-                    Log.Cyan($"Symbol '{docsTypeName}' found in referenced project '{projectPath}'.");
-
-                    // Do not look in referenced projects
-                    Log.Info($"Looking for symbol '{symbol.Name}' in all locations of '{projectPath}'...");
-                    GetMatchingLocationsForSymbolInProject(resolvedLocations, resolvedProject, symbol.Locations, docsTypeName);
-
-                    string monoProjectPath = Regex.Replace(projectPath, @"src(?<separator>[\\\/]{1})coreclr", "src${separator}mono");
-
-                    // If the symbol was found in corelib, try to also find it in mono
-                    if (projectNamespaceToUpper == _systemPrivateCoreLib &&
-                        projectPath.Contains(_pathSrcCoreclr))
-                    {
-                        (ResolvedProject? monoProject, INamedTypeSymbol? monoSymbol) = await TryFindSymbolInReferencedProjectAsync(monoProjectPath, docsTypeName, isMono: true, cancellationToken).ConfigureAwait(false);
-                        if (monoProject != null && monoSymbol != null)
-                        {
-                            Log.Info($"Symbol '{monoSymbol.Name}' was also found in Mono locations of project '{monoProject.Project.FilePath}'.");
-                            GetMatchingLocationsForSymbolInProject(resolvedLocations, monoProject, monoSymbol.Locations, docsTypeName);
-                        }
-                    }
-                }
-                else
-                {
-                    Log.Info(false, $"Symbol for '{docsTypeName}' not found in referenced project '{projectPath}'.");
-                    if (n < projectReferences.Count())
-                    {
-                        Log.Info(true, $" Trying the next project...");
-                    }
-                }
-                n++;
-            }
-        }
-
-        // Checks if the specified tree can be found among the collection of trees of the specified compilation.
-        private static bool IsLocationTreeInCompilationTrees(SyntaxTree tree, Compilation compilation) =>
-            compilation.SyntaxTrees.FirstOrDefault(x => x.FilePath == tree.FilePath) is not null;
-
-        // Tries to find the specified type among the source code files of the specified project.
-        // Returns false if not found.
-        private async Task<(ResolvedProject?, INamedTypeSymbol?)> TryFindSymbolInReferencedProjectAsync(
-            string projectPath, string apiFullName, bool isMono, CancellationToken cancellationToken)
-        {
-            Debug.Assert(_config.Loader != null);
-            ResolvedProject? project = await _config.Loader.LoadProjectAsync(projectPath, isMono, cancellationToken).ConfigureAwait(false);
-            INamedTypeSymbol? symbol = null;
-            if (project != null)
-            {
-                TryGetNamedSymbol(project.Compilation, apiFullName, out symbol);
-            }
-            return (project, symbol);
-        }
-
-        // Retrieves the location of the specified path using reflection.
-        // There is no public API available to retrieve this information.
-        private static string GetProjectPath(ProjectReference projectReference)
-        {
-            PropertyInfo prop = typeof(ProjectId).GetProperty("DebugName", BindingFlags.NonPublic | BindingFlags.Instance)
-                            ?? throw new NullReferenceException("ProjectId.DebugName private property not found.");
-
-            string projectPath = prop.GetValue(projectReference.ProjectId)?.ToString()
-                ?? throw new NullReferenceException("ProjectId.DebugName value was null.");
-
-            if (string.IsNullOrWhiteSpace(projectPath))
-            {
-                throw new Exception("Project path was empty.");
-            }
-
-            return projectPath;
-        }
-
-        // Tries to retrieve the specified symbol from the specified compilation.
-        // Returns true if found.
-        private static bool TryGetNamedSymbol(
-            Compilation compilation,
-            string symbolFullName,
-            [NotNullWhen(returnValue: true)] out INamedTypeSymbol? actualSymbol)
-        {
-            // Try to find the symbol in the current compilation
-            actualSymbol = compilation.GetTypeByMetadataName(symbolFullName) ??
-                           compilation.Assembly.GetTypeByMetadataName(symbolFullName);
-
-            return actualSymbol != null;
-        }
+        [GeneratedRegex("src(?<separator>[\\\\\\/]{1})coreclr")]
+        private static partial Regex MonoProjectPathReplacementRegex();
     }
 }

--- a/src/PortToTripleSlash/tests/PortToTripleSlash/PortToTripleSlashTests.cs
+++ b/src/PortToTripleSlash/tests/PortToTripleSlash/PortToTripleSlashTests.cs
@@ -66,9 +66,9 @@ namespace ApiDocsSync.Libraries.Tests
             await c.Loader.LoadMainProjectAsync(c.CsProj, c.IsMono, cts.Token);
 
             ToTripleSlashPorter porter = new(c);
-            porter.CollectFiles();
-            await porter.MatchSymbolsAsync(throwOnSymbolsNotFound: true, cts.Token);
-            await porter.PortAsync(throwOnSymbolsNotFound: true, cts.Token);
+            porter.TryCollectFiles();
+            await porter.MatchSymbolsAsync(cts.Token);
+            await porter.PortAsync(cts.Token);
 
             Verify(testData);
         }

--- a/src/PortToTripleSlash/tests/PortToTripleSlash/TestData/Basic/MyAssembly.csproj
+++ b/src/PortToTripleSlash/tests/PortToTripleSlash/TestData/Basic/MyAssembly.csproj
@@ -4,6 +4,12 @@
     <OutputType>Library</OutputType>
     <Description>This is MyNamespace description.</Description>
     <TargetFramework>net7.0</TargetFramework>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="SourceOriginal.cs" />
+    <Compile Remove="SourceExpected.cs" />
+  </ItemGroup>
 
 </Project>

--- a/src/PortToTripleSlash/tests/PortToTripleSlash/TestData/Basic/MyDelegate.xml
+++ b/src/PortToTripleSlash/tests/PortToTripleSlash/TestData/Basic/MyDelegate.xml
@@ -1,12 +1,10 @@
-﻿<Type Name="MyDelegate" FullName="MyNamespace.MyType.MyDelegate`1">
-  <TypeSignature Language="DocId" Value="T:MyNamespace.MyType.MyDelegate`1" />
+﻿<Type Name="MyDelegate" FullName="MyNamespace.MyType.MyDelegate">
+  <TypeSignature Language="DocId" Value="T:MyNamespace.MyType.MyDelegate" />
   <AssemblyInfo>
     <AssemblyName>MyAssembly</AssemblyName>
   </AssemblyInfo>
   <Docs>
     <param name="sender">This is the sender parameter.</param>
-    <param name="e">This is the e parameter.</param>
-    <typeparam name="T">This is the MyDelegate typeparam T.</typeparam>
     <summary>This is the MyDelegate summary.</summary>
     <remarks>
       <format type="text/markdown">
@@ -14,11 +12,11 @@
 
 ## Remarks
 
-These are the <xref:MyNamespace.MyType.MyDelegate`1> remarks. There is a code example, which should be moved to its own examples section:
+These are the <xref:MyNamespace.MyType.MyDelegate> remarks. There is a code example, which should be moved to its own examples section:
 
 ## Examples
 
-Here is some text in the examples section. There is an <xref:MyNamespace.MyType.MyDelegate`1> that should be converted to xml.
+Here is some text in the examples section. There is an <xref:MyNamespace.MyType.MyDelegate> that should be converted to xml.
 
 The snippet links below should be inserted in markdown.
 

--- a/src/PortToTripleSlash/tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
+++ b/src/PortToTripleSlash/tests/PortToTripleSlash/TestData/Basic/SourceExpected.cs
@@ -123,6 +123,9 @@ namespace MyNamespace
         /// </remarks>
         public void UndocumentedMethod()
         {
+            // Set MyEvent to a method of the shape of MyDelegate
+            MyEvent = (object sender) => { if (sender is int i) { _otherProperty = i; } }; // Use _otherProperty to remove the unused warning
+            if (MyEvent == null) { } // Use MyEvent to remove the unused warning
         }
 
         /// <summary>This is the MyTypeParamMethod summary.</summary>
@@ -137,11 +140,9 @@ namespace MyNamespace
         }
 
         /// <summary>This is the MyDelegate summary.</summary>
-        /// <typeparam name="T">This is the MyDelegate typeparam T.</typeparam>
         /// <param name="sender">This is the sender parameter.</param>
-        /// <param name="e">This is the e parameter.</param>
-        /// <remarks>These are the <see cref="MyNamespace.MyType.MyDelegate{T}" /> remarks. There is a code example, which should be moved to its own examples section:</remarks>
-        /// <example>Here is some text in the examples section. There is an <see cref="MyNamespace.MyType.MyDelegate{T}" /> that should be converted to xml.
+        /// <remarks>These are the <see cref="MyNamespace.MyType.MyDelegate" /> remarks. There is a code example, which should be moved to its own examples section:</remarks>
+        /// <example>Here is some text in the examples section. There is an <see cref="MyNamespace.MyType.MyDelegate" /> that should be converted to xml.
         /// The snippet links below should be inserted in markdown.
         /// <format type="text/markdown"><![CDATA[
         /// [!code-csharp[MyExample#1](~/samples/snippets/example.cs)]
@@ -153,7 +154,7 @@ namespace MyNamespace
         /// <altmember cref="System.Delegate"/>
         /// <related type="Article" href="https://github.com/dotnet/runtime">The .NET Runtime repo.</related>
         // Original MyDelegate delegate comments with information for maintainers, must stay.
-        public delegate void MyDelegate<T>(object sender, T e);
+        public delegate void MyDelegate(object sender);
 
         /// <summary>This is the MyEvent summary.</summary>
         public event MyDelegate MyEvent;
@@ -164,9 +165,6 @@ namespace MyNamespace
         /// <returns>The added types.</returns>
         /// <remarks>These are the <see cref="MyNamespace.MyType.op_Addition(MyNamespace.MyType,MyNamespace.MyType)" /> remarks. They are in plain xml and should be transferred unmodified.</remarks>
         // Original operator + method comments with information for maintainers, must stay.
-        public static MyType operator +(MyType value1, MyType value2)
-        {
-            return value1;
-        }
+        public static MyType operator +(MyType value1, MyType value2) => value1;
     }
 }

--- a/src/PortToTripleSlash/tests/PortToTripleSlash/TestData/Basic/SourceOriginal.cs
+++ b/src/PortToTripleSlash/tests/PortToTripleSlash/TestData/Basic/SourceOriginal.cs
@@ -69,6 +69,9 @@ namespace MyNamespace
         /// </remarks>
         public void UndocumentedMethod()
         {
+            // Set MyEvent to a method of the shape of MyDelegate
+            MyEvent = (object sender) => { if (sender is int i) { _otherProperty = i; } }; // Use _otherProperty to remove the unused warning
+            if (MyEvent == null) { } // Use MyEvent to remove the unused warning
         }
 
         public void MyTypeParamMethod<T>(int param1)
@@ -76,14 +79,11 @@ namespace MyNamespace
         }
 
         // Original MyDelegate delegate comments with information for maintainers, must stay.
-        public delegate void MyDelegate<T>(object sender, T e);
+        public delegate void MyDelegate(object sender);
 
         public event MyDelegate MyEvent;
 
         // Original operator + method comments with information for maintainers, must stay.
-        public static MyType operator +(MyType value1, MyType value2)
-        {
-            return value1;
-        }
+        public static MyType operator +(MyType value1, MyType value2) => value1;
     }
 }

--- a/src/PortToTripleSlash/tests/PortToTripleSlash/TestData/Generics/MyAssembly.csproj
+++ b/src/PortToTripleSlash/tests/PortToTripleSlash/TestData/Generics/MyAssembly.csproj
@@ -4,6 +4,12 @@
     <OutputType>Library</OutputType>
     <Description>This is MyNamespace description.</Description>
     <TargetFramework>net7.0</TargetFramework>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="SourceOriginal.cs" />
+    <Compile Remove="SourceExpected.cs" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
After fixing the MSBuild problem, the unit tests uncovered a problem when attempting to detect nested types, specifically, delegates. Turns out the way symbols were being visited before was not a proper way of ensuring nested types would also be visited. Instead, I added a CSharpVisitor instance and now all the symbols get pre-collected, and then paired up with the docs types afterwards.

The tests now pass.