### PR TITLE
Fix property tests that are failing

### DIFF
--- a/src/PortToTripleSlash/tests/PortToTripleSlash/PortToTripleSlash.Strings.Tests.cs
+++ b/src/PortToTripleSlash/tests/PortToTripleSlash/PortToTripleSlash.Strings.Tests.cs
@@ -439,6 +439,7 @@ public class MyClass
   <Members>
     <Member MemberName=""MySetProperty"">
       <MemberSignature Language=""DocId"" Value=""P:MyNamespace.MyClass.MySetProperty"" />
+      <MemberType>Property</MemberType>
       <Docs>
         <summary>This is the MySetProperty summary.</summary>
         <value>This is the MySetProperty value.</value>
@@ -488,6 +489,7 @@ public class MyClass
   <Members>
     <Member MemberName=""MyGetProperty"">
       <MemberSignature Language=""DocId"" Value=""P:MyNamespace.MyClass.MyGetProperty"" />
+      <MemberType>Property</MemberType>
       <Docs>
         <summary>This is the MyGetProperty summary.</summary>
         <value>This is the MyGetProperty value.</value>
@@ -537,6 +539,7 @@ public class MyClass
   <Members>
     <Member MemberName=""MyGetSetProperty"">
       <MemberSignature Language=""DocId"" Value=""P:MyNamespace.MyClass.MyGetSetProperty"" />
+      <MemberType>Property</MemberType>
       <Docs>
         <summary>This is the MyGetSetProperty summary.</summary>
         <value>This is the MyGetSetProperty value.</value>


### PR DESCRIPTION
The `DocsMember` elements **must** have a `MemberType`  xml value to indicate if it's a method or a property. I missed adding those in the test xml strings.