### PR TITLE
Additional tests around comment special cases

### DIFF
--- a/src/PortToTripleSlash/tests/PortToTripleSlash/PortToTripleSlash.Strings.Tests.cs
+++ b/src/PortToTripleSlash/tests/PortToTripleSlash/PortToTripleSlash.Strings.Tests.cs
@@ -179,7 +179,6 @@ public enum MyEnum
     [Fact]
     public Task Class_Ctor_Parameterless()
     {
-
         string docId = "T:MyNamespace.MyClass";
 
         string docFile = @"<Type Name=""MyClass"" FullName=""MyNamespace.MyClass"">
@@ -1232,6 +1231,59 @@ public class MyClass : MyInterface
         StringTestData data = new(docFiles, originalCodeFiles, expectedCodeFiles, false);
 
         return TestWithStringsAsync(data);
+    }
+
+    [Fact]
+    public Task Preserve_DoubleSlash_Comments()
+    {
+        string docId = "T:MyNamespace.MyClass";
+
+        string docFile = @"<Type Name=""MyClass"" FullName=""MyNamespace.MyClass"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyClass"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>This is the MyClass type summary.</summary>
+    <remarks>These are the MyClass type remarks.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="".ctor"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyClass.#ctor"" />
+      <Docs>
+        <summary>This is the MyClass constructor summary.</summary>
+        <remarks>These are the MyClass constructor remarks.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+        string originalCode = @"namespace MyNamespace;
+// Comment on top of type
+public class MyClass
+{
+    // Comment on top of constructor
+    public MyClass() { }
+}";
+
+        string expectedCode = @"namespace MyNamespace;
+/// <summary>This is the MyClass type summary.</summary>
+/// <remarks>These are the MyClass type remarks.</remarks>
+// Comment on top of type
+public class MyClass
+{
+    /// <summary>This is the MyClass constructor summary.</summary>
+    /// <remarks>These are the MyClass constructor remarks.</remarks>
+    // Comment on top of constructor
+    public MyClass() { }
+}";
+
+        List<string> docFiles = new() { docFile };
+        List<string> originalCodeFiles = new() { originalCode };
+        Dictionary<string, string> expectedCodeFiles = new() { { docId, expectedCode } };
+        StringTestData stringTestData = new(docFiles, originalCodeFiles, expectedCodeFiles, false);
+
+        return TestWithStringsAsync(stringTestData);
     }
 
     [Fact]

--- a/src/PortToTripleSlash/tests/PortToTripleSlash/PortToTripleSlash.Strings.Tests.cs
+++ b/src/PortToTripleSlash/tests/PortToTripleSlash/PortToTripleSlash.Strings.Tests.cs
@@ -1286,6 +1286,60 @@ public class MyClass
         return TestWithStringsAsync(stringTestData);
     }
 
+    [ActiveIssue("https://github.com/dotnet/api-docs-sync/issues/149")]
+    [Fact]
+    public Task Override_Existing_TripleSlash_Comments()
+    {
+        string docId = "T:MyNamespace.MyClass";
+
+        string docFile = @"<Type Name=""MyClass"" FullName=""MyNamespace.MyClass"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyClass"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>This is the MyClass type summary.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName="".ctor"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyClass.#ctor"" />
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>These are the MyClass constructor remarks.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+        string originalCode = @"namespace MyNamespace;
+/// <summary>Old MyClass type summary.</summary>
+/// <remarks>Old MyClass type remarks.</remarks>
+public class MyClass
+{
+    /// <summary>Old MyClass constructor summary.</summary>
+    /// <remarks>Old MyClass constructor remarks.</remarks>
+    public MyClass() { }
+}";
+
+        string expectedCode = @"namespace MyNamespace;
+/// <summary>This is the MyClass type summary.</summary>
+/// <remarks>Old MyClass type remarks.</remarks>
+public class MyClass
+{
+    /// <summary>Old MyClass constructor summary.</summary>
+    /// <remarks>These are the MyClass constructor remarks.</remarks>
+    public MyClass() { }
+}";
+
+        List<string> docFiles = new() { docFile };
+        List<string> originalCodeFiles = new() { originalCode };
+        Dictionary<string, string> expectedCodeFiles = new() { { docId, expectedCode } };
+        StringTestData stringTestData = new(docFiles, originalCodeFiles, expectedCodeFiles, false);
+
+        return TestWithStringsAsync(stringTestData);
+    }
+
     [Fact]
     public Task Full_Enum()
     {

--- a/src/PortToTripleSlash/tests/tests.csproj
+++ b/src/PortToTripleSlash/tests/tests.csproj
@@ -30,9 +30,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="17.2.0" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Framework" Version="17.2.0" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="8.0.0-beta.22579.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0-preview-20220707-01" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0-preview.6.22324.4" />
-    <PackageReference Include="xunit" Version="2.4.2-pre.22" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Added XUnitExtensions to be able to top tests with known problems using the `ActiveIssue` attribute. Updated required dependency XUnit too.

Add test to verify that double slash comments are preserved.

Add test to verify that triple slash items that have nothing to backport, remain untouched. This test is currently failing and I opened https://github.com/dotnet/api-docs-sync/issues/149 to track it.