### PR TITLE
Fix real scenario execution failure

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '7.0.x'
+        dotnet-version: '8.0.x'
     - name: Restore dependencies of PortToTripleSlash
       run: dotnet restore src/PortToTripleSlash/PortToTripleSlash.sln
     - name: Build PortToTripleSlash

--- a/build.proj
+++ b/build.proj
@@ -1,0 +1,22 @@
+<Project DefaultTargets="Build">
+  <ItemGroup>
+    <Solution Include="**\*.sln" />
+    <TestProject Include="**\**\tests\*.csproj" />
+  </ItemGroup>
+
+  <Target Name="Clean">
+    <MSBuild Projects="@(Solution)" Targets="Clean" />
+  </Target>
+
+  <Target Name="Restore">
+    <MSBuild Projects="@(Solution)" Targets="Restore" />
+  </Target>
+
+  <Target Name="Build">
+    <MSBuild Projects="@(Solution)" Targets="Build" />
+  </Target>
+
+  <Target Name="VSTest">
+    <MSBuild Projects="@(TestProject)" Targets="VSTest" />
+  </Target>
+</Project>

--- a/src/PortToDocs/src/app/PortToDocs.csproj
+++ b/src/PortToDocs/src/app/PortToDocs.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <StartupObject>ApiDocsSync.PortToDocs.PortToDocs</StartupObject>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
-    <Version>1.1</Version>
+    <Version>1.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PortToDocs/src/libraries/libraries.csproj
+++ b/src/PortToDocs/src/libraries/libraries.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/PortToDocs/tests/tests.csproj
+++ b/src/PortToDocs/tests/tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/PortToTripleSlash/src/app/PortToTripleSlash.csproj
+++ b/src/PortToTripleSlash/src/app/PortToTripleSlash.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <StartupObject>ApiDocsSync.PortToTripleSlash.PortToTripleSlash</StartupObject>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
-    <Version>1.2</Version>
+    <Version>1.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PortToTripleSlash/src/libraries/libraries.csproj
+++ b/src/PortToTripleSlash/src/libraries/libraries.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/PortToTripleSlash/src/libraries/libraries.csproj
+++ b/src/PortToTripleSlash/src/libraries/libraries.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="17.4.0" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.5.0-2.final" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4-beta1.22559.1">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/PortToTripleSlash/tests/tests.csproj
+++ b/src/PortToTripleSlash/tests/tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/PortToTripleSlash/tests/tests.csproj
+++ b/src/PortToTripleSlash/tests/tests.csproj
@@ -30,7 +30,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="17.4.0" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Framework" Version="17.4.0" ExcludeAssets="Runtime" />
-    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="8.0.0-beta.23060.7" />
+    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="8.0.0-beta.23103.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0-preview-20221221-03" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/api-docs-sync/issues/155

- Bump the `TargetFramework` of all the api-docs-sync projects to `net8.0`.
- Update the dependencies versions to the latest available in the feeds.
- Add a `build.proj` file in the root folder to make it possible to run `dotnet build/restore/clean/test` from the root folder.
- Bump the versions of the projects to the next number.

Tests:
- Confirmed that the project can be build and tests can be successfully executed from Visual Studio.
- Confirmed that all the `dotnet build/restore/clean/test` commands run successfully from the root.
- Confirmed that `install-as-root.ps1` works well (detects `build.proj` and uses it).
- Confirmed with System.IO.Compression.Brotli that the tool is capable of porting docs.
