### PR TITLE
Fix seealso cref handling

### DIFF
--- a/src/PortToDocs/src/libraries/Configuration.cs
+++ b/src/PortToDocs/src/libraries/Configuration.cs
@@ -33,10 +33,12 @@ namespace ApiDocsSync.PortToDocs
             PortMemberProperties,
             PortMemberReturns,
             PortMemberRemarks,
+            PortMemberSeeAlsos,
             PortMemberSummaries,
             PortMemberTypeParams,
             PortTypeParams, // Params of a Type
             PortTypeRemarks,
+            PortTypeSeeAlsos,
             PortTypeSummaries,
             PortTypeTypeParams, // TypeParams of a Type
             PreserveInheritDocTag,
@@ -88,6 +90,7 @@ namespace ApiDocsSync.PortToDocs
         public bool PortMemberProperties { get; set; } = true;
         public bool PortMemberReturns { get; set; } = true;
         public bool PortMemberRemarks { get; set; } = true;
+        public bool PortMemberSeeAlsos { get; set; } = true;
         public bool PortMemberSummaries { get; set; } = true;
         public bool PortMemberTypeParams { get; set; } = true;
         /// <summary>
@@ -95,6 +98,7 @@ namespace ApiDocsSync.PortToDocs
         /// </summary>
         public bool PortTypeParams { get; set; } = true;
         public bool PortTypeRemarks { get; set; } = true;
+        public bool PortTypeSeeAlsos { get; set; } = true;
         public bool PortTypeSummaries { get; set; } = true;
         /// <summary>
         /// TypeParams of a Type.
@@ -395,6 +399,10 @@ namespace ApiDocsSync.PortToDocs
                                     mode = Mode.PortMemberSummaries;
                                     break;
 
+                                case "-PORTMEMBERSEEALSOS":
+                                    mode = Mode.PortMemberSeeAlsos;
+                                    break;
+
                                 case "-PORTMEMBERTYPEPARAMS":
                                     mode = Mode.PortMemberTypeParams;
                                     break;
@@ -405,6 +413,10 @@ namespace ApiDocsSync.PortToDocs
 
                                 case "-PORTTYPEREMARKS":
                                     mode = Mode.PortTypeRemarks;
+                                    break;
+
+                                case "-PORTTYPESEEALSOS":
+                                    mode = Mode.PortTypeSeeAlsos;
                                     break;
 
                                 case "-PORTTYPESUMMARIES":
@@ -516,6 +528,13 @@ namespace ApiDocsSync.PortToDocs
                             break;
                         }
 
+                    case Mode.PortMemberSeeAlsos:
+                        {
+                            config.PortMemberSeeAlsos = ParseOrExit(arg, "Port member SeeAlsos");
+                            mode = Mode.Initial;
+                            break;
+                        }
+
                     case Mode.PortMemberSummaries:
                         {
                             config.PortMemberSummaries = ParseOrExit(arg, "Port member Summaries");
@@ -540,6 +559,13 @@ namespace ApiDocsSync.PortToDocs
                     case Mode.PortTypeRemarks:
                         {
                             config.PortTypeRemarks = ParseOrExit(arg, "Port Type Remarks");
+                            mode = Mode.Initial;
+                            break;
+                        }
+
+                    case Mode.PortTypeSeeAlsos:
+                        {
+                            config.PortTypeSeeAlsos = ParseOrExit(arg, "Port type SeeAlsos");
                             mode = Mode.Initial;
                             break;
                         }
@@ -802,6 +828,12 @@ Options:
                                                     Usage example:
                                                         -PortMemberRemarks false
 
+    -PortMemberSeeAlsos         bool            Default is true (ports Member seealsos).
+                                                Enable or disable finding and porting Member seealsos.
+                                                These are found directly under the Docs xml element.
+                                                    Usage example:
+                                                        -PortMemberSeeAlsos false
+
     -PortMemberSummaries        bool            Default is true (ports Member summaries).
                                                 Enable or disable finding and porting Member summaries.
                                                     Usage example:
@@ -821,6 +853,12 @@ Options:
                                                 Enable or disable finding and porting Type remarks.
                                                     Usage example:
                                                         -PortTypeRemarks false
+
+    -PortTypeSeeAlsos           bool            Default is true (ports Type seealsos).
+                                                Enable or disable finding and porting Type seealsos.
+                                                These are found directly under the Docs xml element.
+                                                    Usage example:
+                                                        -PortTypeSeeAlsos false
 
     -PortTypeSummaries          bool            Default is true (ports Type summaries).
                                                 Enable or disable finding and porting Type summaries.

--- a/src/PortToDocs/src/libraries/Docs/DocsAPI.cs
+++ b/src/PortToDocs/src/libraries/Docs/DocsAPI.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -18,7 +18,7 @@ namespace ApiDocsSync.PortToDocs.Docs
         private List<DocsTypeParameter>? _typeParameters;
         private List<DocsTypeParam>? _typeParams;
         private List<DocsAssemblyInfo>? _assemblyInfos;
-        private List<string>? _seeAlsoCrefs;
+        private List<DocsSeeAlso>? _seeAlsos;
         private List<string>? _altMemberCrefs;
         private List<DocsRelated>? _relateds;
         private XElement? _xInheritDoc = null;
@@ -140,22 +140,22 @@ namespace ApiDocsSync.PortToDocs.Docs
             }
         }
 
-        public List<string> SeeAlsoCrefs
+        public List<DocsSeeAlso> SeeAlsos
         {
             get
             {
-                if (_seeAlsoCrefs == null)
+                if (_seeAlsos == null)
                 {
                     if (Docs != null)
                     {
-                        _seeAlsoCrefs = Docs.Elements("seealso").Select(x => XmlHelper.GetAttributeValue(x, "cref")).ToList();
+                        _seeAlsos = Docs.Elements("seealso").Select(x => new DocsSeeAlso(this, x)).ToList();
                     }
                     else
                     {
-                        _seeAlsoCrefs = new();
+                        _seeAlsos = new();
                     }
                 }
-                return _seeAlsoCrefs;
+                return _seeAlsos;
             }
         }
 
@@ -308,6 +308,15 @@ namespace ApiDocsSync.PortToDocs.Docs
             XmlHelper.AddChildFormattedAsXml(Docs, typeParam, value);
             Changed = true;
             return new DocsTypeParam(this, typeParam);
+        }
+
+        public DocsSeeAlso AddSeeAlso(string cref)
+        {
+            XElement seeAlso = new XElement("seealso");
+            seeAlso.SetAttributeValue("cref", cref);
+            Docs.Add(seeAlso);
+            Changed = true;
+            return new DocsSeeAlso(this, seeAlso);
         }
 
         // For Types, these elements are called TypeSignature.

--- a/src/PortToDocs/src/libraries/Docs/DocsMember.cs
+++ b/src/PortToDocs/src/libraries/Docs/DocsMember.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;

--- a/src/PortToDocs/src/libraries/Docs/DocsSeeAlso.cs
+++ b/src/PortToDocs/src/libraries/Docs/DocsSeeAlso.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Xml.Linq;
+
+namespace ApiDocsSync.PortToDocs.Docs;
+
+internal class DocsSeeAlso
+{
+    private readonly XElement XESeeAlso;
+
+    public IDocsAPI ParentAPI
+    {
+        get; private set;
+    }
+
+    public string Cref => XmlHelper.GetAttributeValue(XESeeAlso, "cref");
+
+    public DocsSeeAlso(IDocsAPI parentAPI, XElement xSeeAlso)
+    {
+        ParentAPI = parentAPI;
+        XESeeAlso = xSeeAlso;
+    }
+
+    public override string ToString() => $"seealso cref={Cref}";
+}

--- a/src/PortToDocs/src/libraries/IntelliSenseXml/IntelliSenseXmlMember.cs
+++ b/src/PortToDocs/src/libraries/IntelliSenseXml/IntelliSenseXmlMember.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -107,6 +107,19 @@ namespace ApiDocsSync.PortToDocs.IntelliSenseXml
             }
         }
 
+        private List<IntelliSenseXmlSeeAlso>? _seeAlsos;
+        public IEnumerable<IntelliSenseXmlSeeAlso> SeeAlsos
+        {
+            get
+            {
+                if (_seeAlsos == null)
+                {
+                    _seeAlsos = XEMember.Elements("seealso").Select(x => new IntelliSenseXmlSeeAlso(x)).ToList();
+                }
+                return _seeAlsos;
+            }
+        }
+
         private string? _summary;
         public string Summary
         {
@@ -116,6 +129,7 @@ namespace ApiDocsSync.PortToDocs.IntelliSenseXml
                 {
                     XElement? xElement = XEMember.Element("summary");
                     _summary = (xElement != null) ? XmlHelper.GetNodesInPlainText(xElement) : string.Empty;
+                    _summary = XmlHelper.ReplaceSeeAlsos(_summary);
                 }
                 return _summary;
             }

--- a/src/PortToDocs/src/libraries/IntelliSenseXml/IntelliSenseXmlSeeAlso.cs
+++ b/src/PortToDocs/src/libraries/IntelliSenseXml/IntelliSenseXmlSeeAlso.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Xml.Linq;
+
+namespace ApiDocsSync.PortToDocs.IntelliSenseXml;
+
+internal class IntelliSenseXmlSeeAlso(XElement xeSeeAlso)
+{
+    public XElement XESeeAlso
+    {
+        get;
+        private set;
+    } = xeSeeAlso;
+
+    private string _cref = string.Empty;
+    public string Cref
+    {
+        get
+        {
+            if (string.IsNullOrWhiteSpace(_cref))
+            {
+                _cref = XmlHelper.GetAttributeValue(XESeeAlso, "cref");
+            }
+            return _cref;
+        }
+    }
+
+    public override string ToString() => $"SeeAlso cref={Cref}";
+}

--- a/src/PortToDocs/src/libraries/ToDocsPorter.cs
+++ b/src/PortToDocs/src/libraries/ToDocsPorter.cs
@@ -970,7 +970,7 @@ namespace ApiDocsSync.PortToDocs
 
         private void TryPortMissingSeeAlsosForMember(DocsAPI dAPIToUpdate, IntelliSenseXmlMember? tsMemberToPort)
         {
-            if (!Config.PortMemberSeeAlsos || tsMemberToPort == null)
+            if ((dAPIToUpdate.Kind == APIKind.Member && !Config.PortMemberSeeAlsos) || (dAPIToUpdate.Kind == APIKind.Type && !Config.PortTypeSeeAlsos) || tsMemberToPort == null)
             {
                 return;
             }

--- a/src/PortToDocs/src/libraries/ToDocsPorter.cs
+++ b/src/PortToDocs/src/libraries/ToDocsPorter.cs
@@ -239,6 +239,8 @@ namespace ApiDocsSync.PortToDocs
                     TryPortMissingReturnsForMember(dTypeToUpdate, mc.Returns);
                 }
 
+                TryPortMissingSeeAlsosForMember(dTypeToUpdate, tsTypeToPort);
+
                 if (dTypeToUpdate.Changed)
                 {
                     ModifiedTypes.Add(docId);
@@ -308,6 +310,8 @@ namespace ApiDocsSync.PortToDocs
                 {
                     TryPortMissingReturnsForMember(dMemberToUpdate, mc.Returns, mc.IsEII);
                 }
+
+                TryPortMissingSeeAlsosForMember(dMemberToUpdate, tsMemberToPort);
 
                 if (dMemberToUpdate.Changed)
                 {
@@ -960,6 +964,24 @@ namespace ApiDocsSync.PortToDocs
                             TotalModifiedIndividualElements++;
                         }
                     }
+                }
+            }
+        }
+
+        private void TryPortMissingSeeAlsosForMember(DocsAPI dAPIToUpdate, IntelliSenseXmlMember? tsMemberToPort)
+        {
+            if (!Config.PortMemberSeeAlsos || tsMemberToPort == null)
+            {
+                return;
+            }
+
+            foreach (IntelliSenseXmlSeeAlso tsSeeAlso in tsMemberToPort.SeeAlsos)
+            {
+                if (!dAPIToUpdate.SeeAlsos.Any(x => x.Cref == tsSeeAlso.Cref))
+                {
+                    dAPIToUpdate.AddSeeAlso(tsSeeAlso.Cref);
+                    PrintModifiedMember("seealso", dAPIToUpdate.FilePath, tsSeeAlso.Cref, isEII: false);
+                    TotalModifiedIndividualElements++;
                 }
             }
         }

--- a/src/PortToDocs/src/libraries/XmlHelper.cs
+++ b/src/PortToDocs/src/libraries/XmlHelper.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -31,6 +31,11 @@ namespace ApiDocsSync.PortToDocs
             { "True ",          "<see langword=\"true\" /> " },
             { "False ",         "<see langword=\"false\" /> " },
             { "></see>",        " />" }
+        };
+
+        private static readonly Dictionary<string, string> _replaceableSeeAlsos = new Dictionary<string, string>
+        {
+            { "seealso cref", "see cref" }
         };
 
         private static readonly Dictionary<string, string> _replaceableNormalElementRegexPatterns = new Dictionary<string, string>
@@ -297,26 +302,19 @@ namespace ApiDocsSync.PortToDocs
             return value.Trim();
         }
 
-        private static string ReplaceMarkdownPatterns(string value)
-        {
-            string updatedValue = value;
-            foreach (KeyValuePair<string, string> kvp in _replaceableMarkdownPatterns)
-            {
-                if (updatedValue.Contains(kvp.Key))
-                {
-                    updatedValue = updatedValue.Replace(kvp.Key, kvp.Value);
-                }
-            }
-            return updatedValue;
-        }
-
         internal static string ReplaceExceptionPatterns(string value) =>
-            Regex.Replace(value, @"[\r\n\t ]+\-[ ]?or[ ]?\-[\r\n\t ]+", "\n\n-or-\n\n");
+            Regex.Replace(value, @"[\r\n\t ]+\-[ ]*(or|OR)[ ]*\-[\r\n\t ]+", "\n\n-or-\n\n");
 
-        private static string ReplaceNormalElementPatterns(string value)
+        internal static string ReplaceSeeAlsos(string value) => ReplacePatterns(value, _replaceableSeeAlsos);
+
+        private static string ReplaceMarkdownPatterns(string value) => ReplacePatterns(value, _replaceableMarkdownPatterns);
+
+        private static string ReplaceNormalElementPatterns(string value) => ReplacePatterns(value, _replaceableNormalElementPatterns);
+
+        private static string ReplacePatterns(string value, Dictionary<string, string> patterns)
         {
             string updatedValue = value;
-            foreach (KeyValuePair<string, string> kvp in _replaceableNormalElementPatterns)
+            foreach (KeyValuePair<string, string> kvp in patterns)
             {
                 if (updatedValue.Contains(kvp.Key))
                 {

--- a/src/PortToDocs/tests/PortToDocs.Strings.Tests.cs
+++ b/src/PortToDocs/tests/PortToDocs.Strings.Tests.cs
@@ -526,6 +526,7 @@ I have a reference to the generic type <xref:MyNamespace.MyGenericType%601> and 
         public void SeeAlso_Cref()
         {
             // Normally, references to other APIs are indicated with <see cref="X:DocId"/> in xml, or with <xref:DocId> in markdown. But there are some rare cases where <seealso cref="X:DocId"/> is used, and we need to make sure to handle them just as see crefs.
+            // The only ones that need to be preserved unmodified are the ones that are outside a documentation element (directly under Docs).
 
             string originalIntellisense = @"<?xml version=""1.0""?>
 <doc>
@@ -539,6 +540,7 @@ I have a reference to the generic type <xref:MyNamespace.MyGenericType%601> and 
     <member name=""M:MyNamespace.MyType.MyMethod"">
       <summary>The summary of MyMethod. See <seealso cref=""M:MyNamespace.MyType.MyMethod"" />.</summary>
       <remarks>See <seealso cref=""M:MyNamespace.MyType.MyMethod"" />.</remarks>
+      <seealso cref=""T:MyNamespace.MyType"" />
     </member>
   </members>
 </doc>";
@@ -551,6 +553,7 @@ I have a reference to the generic type <xref:MyNamespace.MyGenericType%601> and 
   <Docs>
     <summary>To be added.</summary>
     <remarks>To be added.</remarks>
+    <seealso cref=""M:MyNamespace.MyType.MyMethod"" />
   </Docs>
   <Members>
     <Member MemberName=""MyMethod"">
@@ -576,8 +579,9 @@ I have a reference to the generic type <xref:MyNamespace.MyGenericType%601> and 
     <AssemblyName>MyAssembly</AssemblyName>
   </AssemblyInfo>
   <Docs>
-    <summary>See <seealso cref=""T:MyNamespace.MyType"" />.</summary>
+    <summary>See <see cref=""T:MyNamespace.MyType"" />.</summary>
     <remarks>To be added.</remarks>
+    <seealso cref=""M:MyNamespace.MyType.MyMethod"" />
   </Docs>
   <Members>
     <Member MemberName=""MyMethod"">
@@ -590,7 +594,7 @@ I have a reference to the generic type <xref:MyNamespace.MyGenericType%601> and 
         <ReturnType>System.Void</ReturnType>
       </ReturnValue>
       <Docs>
-        <summary>The summary of MyMethod. See <seealso cref=""M:MyNamespace.MyType.MyMethod"" />.</summary>
+        <summary>The summary of MyMethod. See <see cref=""M:MyNamespace.MyType.MyMethod"" />.</summary>
         <remarks>
           <format type=""text/markdown""><![CDATA[
 
@@ -600,6 +604,7 @@ See <xref:MyNamespace.MyType.MyMethod>.
 
           ]]></format>
         </remarks>
+        <seealso cref=""T:MyNamespace.MyType"" />
       </Docs>
     </Member>
   </Members>

--- a/src/PortToDocs/tests/PortToDocs.Strings.Tests.cs
+++ b/src/PortToDocs/tests/PortToDocs.Strings.Tests.cs
@@ -621,6 +621,184 @@ See <xref:MyNamespace.MyType.MyMethod>.
         }
 
         [Fact]
+        public void SeeAlso_SkipPortingForMembers()
+        {
+            // Do not port seealso elements for members if specified in CLI argument.
+
+            string originalIntellisense = @"<?xml version=""1.0""?>
+<doc>
+  <assembly>
+    <name>MyAssembly</name>
+  </assembly>
+  <members>
+    <member name=""T:MyNamespace.MyType"">
+      <summary>To be added.</summary>
+      <seealso cref=""M:MyNamespace.MyType.MyMethod"" />
+    </member>
+    <member name=""M:MyNamespace.MyType.MyMethod"">
+      <summary>To be added.</summary>
+      <remarks>To be added.</remarks>
+      <seealso cref=""T:MyNamespace.MyType"" />
+    </member>
+  </members>
+</doc>";
+
+            string originalDocs = @"<Type Name=""MyType"" FullName=""MyNamespace.MyType"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=""MyMethod"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyMethod"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+            string expectedDocs = @"<Type Name=""MyType"" FullName=""MyNamespace.MyType"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+    <seealso cref=""M:MyNamespace.MyType.MyMethod"" />
+  </Docs>
+  <Members>
+    <Member MemberName=""MyMethod"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyMethod"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+
+            Configuration configuration = new()
+            {
+                PortTypeSeeAlsos = true,
+                PortMemberSeeAlsos = false
+            };
+            configuration.IncludedAssemblies.Add(FileTestData.TestAssembly);
+
+            TestWithStrings(originalIntellisense, originalDocs, expectedDocs, configuration);
+        }
+
+        [Fact]
+        public void SeeAlso_SkipPortingForTypes()
+        {
+            // Do not port seealso elements for types if specified in CLI argument.
+
+            string originalIntellisense = @"<?xml version=""1.0""?>
+<doc>
+  <assembly>
+    <name>MyAssembly</name>
+  </assembly>
+  <members>
+    <member name=""T:MyNamespace.MyType"">
+      <summary>To be added.</summary>
+      <seealso cref=""M:MyNamespace.MyType.MyMethod"" />
+    </member>
+    <member name=""M:MyNamespace.MyType.MyMethod"">
+      <summary>To be added.</summary>
+      <remarks>To be added.</remarks>
+      <seealso cref=""T:MyNamespace.MyType"" />
+    </member>
+  </members>
+</doc>";
+
+            string originalDocs = @"<Type Name=""MyType"" FullName=""MyNamespace.MyType"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=""MyMethod"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyMethod"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+            string expectedDocs = @"<Type Name=""MyType"" FullName=""MyNamespace.MyType"">
+  <TypeSignature Language=""DocId"" Value=""T:MyNamespace.MyType"" />
+  <AssemblyInfo>
+    <AssemblyName>MyAssembly</AssemblyName>
+  </AssemblyInfo>
+  <Docs>
+    <summary>To be added.</summary>
+    <remarks>To be added.</remarks>
+  </Docs>
+  <Members>
+    <Member MemberName=""MyMethod"">
+      <MemberSignature Language=""DocId"" Value=""M:MyNamespace.MyType.MyMethod"" />
+      <MemberType>Method</MemberType>
+      <AssemblyInfo>
+        <AssemblyName>MyAssembly</AssemblyName>
+      </AssemblyInfo>
+      <ReturnValue>
+        <ReturnType>System.Void</ReturnType>
+      </ReturnValue>
+      <Docs>
+        <summary>To be added.</summary>
+        <remarks>To be added.</remarks>
+        <seealso cref=""T:MyNamespace.MyType"" />
+      </Docs>
+    </Member>
+  </Members>
+</Type>";
+
+
+            Configuration configuration = new()
+            {
+                PortTypeSeeAlsos = false,
+                PortMemberSeeAlsos = true
+            };
+            configuration.IncludedAssemblies.Add(FileTestData.TestAssembly);
+
+            TestWithStrings(originalIntellisense, originalDocs, expectedDocs, configuration);
+        }
+
+        [Fact]
         public void See_Langword()
         {
             // Reserved words are indicated with <see langword="word" />. They need to be copied as <see langword="word" /> in xml, or transformed to `word` in markdown.


### PR DESCRIPTION
@gewarren 

I noticed the seealso cref elements inside other xml elements like summary, returns, etc. were not being converted to see crefs, so I fixed that.

I made sure to preserve seealso cref elements that are outside those xml elements, or in other words, direct children of the Docs element.

Added test to verify this. All tests pass locally.