### PR TITLE
Fix bug in code data-dev-comment conversions.

### DIFF
--- a/src/PortToDocs/src/app/PortToDocs.csproj
+++ b/src/PortToDocs/src/app/PortToDocs.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
-    <Version>1.3</Version>
+    <Version>1.4</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PortToDocs/src/libraries/XmlHelper.cs
+++ b/src/PortToDocs/src/libraries/XmlHelper.cs
@@ -61,8 +61,10 @@ namespace ApiDocsSync.PortToDocs
             { @"\<(see|seealso){1} cref\=""object""[ ]*\/\>",  "<see cref=\"T:System.Object\" />" },
             { @"\<(see|seealso){1} cref\=""dynamic""[ ]*\/\>", "<see langword=\"dynamic\" />" },
             { @"\<(see|seealso){1} cref\=""string""[ ]*\/\>",  "<see cref=\"T:System.String\" />" },
-            { @"<code data-dev-comment-type=""(?<elementName>[a-zA-Z0-9_]+)"">(?<elementValue>[a-zA-Z0-9_]+)</code>", "<see ${elementName}=\"${elementValue}\" />" },
-            { @"<xref data-throw-if-not-resolved=""[a-zA-Z0-9_]+"" uid=""(?<docId>[a-zA-Z0-9_,\<\>\.\@\#\$%^&`\(\)]+)""><\/xref>", "<see cref=\"T:${docId}\" />" },
+            { @"<code data-dev-comment-type=""langword"">(?<elementValue>[a-zA-Z0-9_]+)</code>", "<see langword=\"${elementValue}\" />" },
+            { @"<code data-dev-comment-type=""paramref"">(?<elementValue>[a-zA-Z0-9_]+)</code>", "<paramref name=\"${elementValue}\" />" },
+            { @"<code data-dev-comment-type=""typeparamref"">(?<elementValue>[a-zA-Z0-9_]+)</code>", "<typeparamref name=\"${elementValue}\" />" },
+            { @"<xref data-throw-if-not-resolved=""[a-zA-Z0-9_]+"" uid=""(?<docId>[a-zA-Z0-9_,\<\>\.\@\#\$%^&`\(\)]+)""(><\/xref>|[ ]*/>)", "<see cref=\"T:${docId}\" />" },
         };
 
         private static readonly Dictionary<string, string> _replaceableMarkdownPatterns = new Dictionary<string, string> {
@@ -123,7 +125,7 @@ namespace ApiDocsSync.PortToDocs
             { @"\<(typeparamref|paramref){1} name\=""(?'refNameContents'[a-zA-Z0-9_\-]+)""[ ]*\/\>",  @"`${refNameContents}`" },
             { @"\<see langword\=""(?'seeLangwordContents'[a-zA-Z0-9_\-]+)""[ ]*\/\>",  @"`${seeLangwordContents}`" },
             { @"<code data-dev-comment-type=""[a-zA-Z0-9_]+"">(?<elementValue>[a-zA-Z0-9_]+)</code>", "`${elementValue}`" },
-            { @"<xref data-throw-if-not-resolved=""[a-zA-Z0-9_]+"" uid=""(?<docId>[a-zA-Z0-9_,\<\>\.]+)""><\/xref>", "<xref:${docId}>" },
+            { @"<xref data-throw-if-not-resolved=""[a-zA-Z0-9_]+"" uid=""(?<docId>[a-zA-Z0-9_,\<\>\.]+)""(><\/xref>|[ ]*/>)", "<xref:${docId}>" },
         };
 
         private static readonly string[] _splittingSeparators = new string[] { "\r", "\n", "\r\n" };

--- a/src/PortToDocs/tests/PortToDocs.Strings.Tests.cs
+++ b/src/PortToDocs/tests/PortToDocs.Strings.Tests.cs
@@ -2503,7 +2503,7 @@ I am paragraph number three.</summary>
     <AssemblyName>MyAssembly</AssemblyName>
   </AssemblyInfo>
   <Docs>
-    <summary>Langword <see langword=""true"" />. Paramref <see paramref=""myParam"" />. Typeparamref <see typeparamref=""myTypeParam"" />.</summary>
+    <summary>Langword <see langword=""true"" />. Paramref <paramref name=""myParam"" />. Typeparamref <typeparamref name=""myTypeParam"" />.</summary>
     <remarks>
       <format type=""text/markdown""><![CDATA[
 


### PR DESCRIPTION
Just found that I grouped langword, paramref and typeparamref into the same conversion. Only langword should use `see`, the other two have their own tag names.

Found bug in https://github.com/dotnet/dotnet-api-docs/pull/10212