### PR TITLE
Minor README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repo contains two tools that allow porting documentation in two directions:
 
 ## Requirements
 
-- [.NET 6.0 SDK](https://github.com/dotnet/installer#installers-and-binaries)
+- [.NET 8.0 SDK](https://get.dot.net/)
 - A local git clone of a dotnet repo with source code whose APIs live in an API docs repo. Examples:
   - [dotnet/runtime](https://github.com/dotnet/runtime)
   - [dotnet/winforms](https://github.com/dotnet/winforms)


### PR DESCRIPTION
* The tools have since been update to use .NET 8 over .NET 6.
* The dotnet/installer repository is empty now. Change the install link to the official install location.